### PR TITLE
Rerender on entrypoint change, fix eval vs render-until-settled promise order

### DIFF
--- a/lib/components/RunFrame.tsx
+++ b/lib/components/RunFrame.tsx
@@ -122,6 +122,7 @@ export const RunFrame = (props: Props) => {
     lastEntrypointRef.current = props.entrypoint
 
     async function runWorker() {
+      debug("running render worker")
       const worker =
         globalThis.runFrameWorker ??
         (await createCircuitWebWorker({
@@ -147,7 +148,12 @@ export const RunFrame = (props: Props) => {
         })
 
       debug("waiting for initial circuit json...")
-      let circuitJson = await worker.getCircuitJson()
+      let circuitJson = await worker.getCircuitJson().catch((e: any) => {
+        debug("error getting initial circuit json", e)
+        props.onError?.(e)
+        return null
+      })
+      if (!circuitJson) return
       debug("got initial circuit json")
       setCircuitJson(circuitJson)
       props.onCircuitJsonChange?.(circuitJson)
@@ -163,7 +169,7 @@ export const RunFrame = (props: Props) => {
       props.onRenderFinished?.({ circuitJson })
     }
     runWorker()
-  }, [props.fsMap])
+  }, [props.fsMap, props.entrypoint])
 
   return (
     <CircuitJsonPreview

--- a/lib/components/RunFrame.tsx
+++ b/lib/components/RunFrame.tsx
@@ -123,7 +123,8 @@ export const RunFrame = (props: Props) => {
 
     async function runWorker() {
       debug("running render worker")
-      const worker =
+      // setError(null)
+      const worker: Awaited<ReturnType<typeof createCircuitWebWorker>> =
         globalThis.runFrameWorker ??
         (await createCircuitWebWorker({
           webWorkerUrl: evalWebWorkerBlobUrl,
@@ -135,22 +136,37 @@ export const RunFrame = (props: Props) => {
       const fsMapObj =
         fsMap instanceof Map ? Object.fromEntries(fsMap.entries()) : fsMap
 
-      const $finished = worker
+      if (!fsMapObj[props.entrypoint]) {
+        setError({
+          error: `Entrypoint not found (entrypoint: "${props.entrypoint}", fsMapKeys: ${Object.keys(fsMapObj).join(", ")})`,
+          stack: "",
+        })
+        return
+      }
+
+      const evalResult = await worker
         .executeWithFsMap({
           entrypoint: props.entrypoint,
           fsMap: fsMapObj,
         })
+        .then(() => ({ success: true }))
         .catch((e: any) => {
           // removing the prefix "Eval compiled js error for "./main.tsx":"
           const message = e.message.split(":")[1]
+          props.onError?.(e)
           setError({ error: message, stack: e.stack })
           console.error(e)
+          return { success: false }
         })
+      if (!evalResult.success) return
+
+      const $renderResult = worker.renderUntilSettled()
 
       debug("waiting for initial circuit json...")
       let circuitJson = await worker.getCircuitJson().catch((e: any) => {
         debug("error getting initial circuit json", e)
         props.onError?.(e)
+        setError({ error: e.message, stack: e.stack })
         return null
       })
       if (!circuitJson) return
@@ -159,8 +175,7 @@ export const RunFrame = (props: Props) => {
       props.onCircuitJsonChange?.(circuitJson)
       props.onInitialRender?.({ circuitJson })
 
-      debug("waiting for execution to finish...")
-      await $finished
+      await $renderResult
 
       debug("getting final circuit json")
       circuitJson = await worker.getCircuitJson()

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -92,9 +92,6 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
         markRenderComplete()
       }}
       entrypoint={entrypoint}
-      onError={(error) => {
-        console.error("RunFrame error:", error)
-      }}
       editEvents={editEventsForRender}
       onEditEvent={(ee) => {
         pushEditEvent(ee)

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { RunFrame } from "../RunFrame"
-import { useRunFrameStore, selectCurrentFileMap } from "./store"
+import { useRunFrameStore } from "./store"
 import type { ManualEditEvent } from "@tscircuit/props"
 import { API_BASE } from "./api-base"
 import { useEditEventController } from "lib/hooks/use-edit-event-controller"

--- a/lib/components/RunFrameWithApi/store.ts
+++ b/lib/components/RunFrameWithApi/store.ts
@@ -76,6 +76,7 @@ export const useRunFrameStore = create<RunFrameState>()(
 
       loadInitialFiles: async () => {
         const fsMap = await getInitialFilesApi()
+        debug("loaded initial files", { fsMap })
         set({ fsMap })
       },
 
@@ -207,7 +208,3 @@ export const useRunFrameStore = create<RunFrameState>()(
     { name: "run-frame-store" },
   ),
 )
-
-// Export selector for current file map
-export const selectCurrentFileMap = (state: RunFrameState) =>
-  Object.fromEntries(state.fsMap.entries())


### PR DESCRIPTION
- **fix entrypoint not triggering re-render**
- **fix rendering vs eval promises for correct order**
