### PR TITLE
fix: hide preview graphics after PCB traces are rendered

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -287,6 +287,7 @@ export const RunFrame = (props: RunFrameProps) => {
       props.onCircuitJsonChange?.(circuitJson)
       setCircuitJson(circuitJson)
       props.onRenderFinished?.({ circuitJson })
+      setAutoroutingGraphics(null)
 
       if (activeTab === "render_log") {
         renderLog.phaseTimings = getPhaseTimingsFromRenderEvents(


### PR DESCRIPTION
fixes #353 
/claim #353 

https://github.com/user-attachments/assets/7e8ff6fa-a3f6-4993-8e8d-524a7eddafc2

