### PR TITLE
fix: error tab content gets cut off in full screen mode

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -468,16 +468,23 @@ export const CircuitJsonPreview = ({
             </div>
           </TabsContent>
           <TabsContent value="errors">
-            {circuitJson || errorMessage ? (
-              <ErrorTabContent
-                code={code}
-                errorMessage={errorMessage}
-                autoroutingLog={autoroutingLog}
-                onReportAutoroutingLog={onReportAutoroutingLog}
-              />
-            ) : (
-              <PreviewEmptyState onRunClicked={onRunClicked} />
-            )}
+            <div
+              className={cn(
+                "rf-overflow-auto",
+                isFullScreen ? "rf-h-[calc(100vh-96px)]" : "rf-h-[620px]",
+              )}
+            >
+              {circuitJson || errorMessage ? (
+                <ErrorTabContent
+                  code={code}
+                  errorMessage={errorMessage}
+                  autoroutingLog={autoroutingLog}
+                  onReportAutoroutingLog={onReportAutoroutingLog}
+                />
+              ) : (
+                <PreviewEmptyState onRunClicked={onRunClicked} />
+              )}
+            </div>
           </TabsContent>
           {showRenderLogTab && (
             <TabsContent value="render_log">


### PR DESCRIPTION
Sorry, I missed this in my last PR. I couldn't see the cut off in the cli example, but in run button example, I noticed the issue.


Before
<img width="1470" alt="Screenshot 2025-03-21 at 3 35 55 PM" src="https://github.com/user-attachments/assets/25e54702-525d-4bee-8831-6f32f5d22dec" />


After
<img width="1470" alt="Screenshot 2025-03-21 at 3 36 39 PM" src="https://github.com/user-attachments/assets/681fe115-ef0e-4bcd-bba4-426037b9fa00" />
