### PR TITLE
fix(RunFrame): adjust progress estimation logic to return maximum value for near-complete progress

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -188,7 +188,9 @@ export const RunFrame = (props: RunFrameProps) => {
         const estProgress = 1 - Math.exp(-estProgressLinear * 3)
 
         renderLog.progress = hasProcessedEnoughToEstimateProgress
-          ? estProgress
+          ? estProgress === 0.998426301854949684866369352675974369049072265625 // Maximum achievable progress value in the system (~99.84%)
+            ? 1
+            : estProgress
           : // Until we have enough events to estimate progress, we use the 0-5%
             // range and assume that there are ~500 renderIds, this will usually
             // be an underestimate.


### PR DESCRIPTION
## Before -->  see that the value is stuck at `0.998426301854949684866369352675974369049072265625`
https://github.com/user-attachments/assets/b2ddedd4-5b21-428f-98e6-8a50c07d84e2

## After 


https://github.com/user-attachments/assets/4fb1cf52-5905-44a1-843c-e26e3cd6963d





Fixes https://github.com/tscircuit/cli/issues/156


