### PR TITLE
feat(RunFrameWithApi): dynamically set document title based on package.json or entrypoint

### DIFF
--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -56,23 +56,28 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
 
   useEffect(() => {
     if (!document || !fsMap) return
-    const fileKeys = Array.from(fsMap.keys())
-    const entrypoint = guessEntrypoint(fileKeys)
-    const packageJsonContent = fsMap.get("package.json")
 
-    try {
-      if (packageJsonContent) {
-        const parsedPackageJson = JSON.parse(packageJsonContent)
-        if (parsedPackageJson?.name) {
-          document.title = parsedPackageJson.name
-          return
+    const setCircuitTitle = () => {
+      const fileKeys = Array.from(fsMap.keys())
+      const entrypoint = guessEntrypoint(fileKeys)
+      const packageJsonContent = fsMap.get("package.json")
+
+      try {
+        if (packageJsonContent) {
+          const parsedPackageJson = JSON.parse(packageJsonContent)
+          if (parsedPackageJson?.name) {
+            document.title = parsedPackageJson.name
+            return
+          }
         }
-      }
-    } catch (e) {}
+      } catch (e) {}
 
-    if (entrypoint) {
-      document.title = entrypoint
+      if (entrypoint) {
+        document.title = entrypoint
+      }
     }
+
+    setCircuitTitle()
   }, [fsMap])
 
   const {

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -54,6 +54,32 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
     loadInitialFiles()
   }, [])
 
+  useEffect(() => {
+    if (!document || !fsMap) return
+
+    const setCircuitTitle = () => {
+      const fileKeys = Array.from(fsMap.keys())
+      const entrypoint = guessEntrypoint(fileKeys)
+      const packageJsonContent = fsMap.get("package.json")
+
+      try {
+        if (packageJsonContent) {
+          const parsedPackageJson = JSON.parse(packageJsonContent)
+          if (parsedPackageJson?.name) {
+            document.title = parsedPackageJson.name
+            return
+          }
+        }
+      } catch (e) {}
+
+      if (entrypoint) {
+        document.title = entrypoint
+      }
+    }
+
+    setCircuitTitle()
+  }, [fsMap])
+
   const {
     editEventsForRender,
     pushEditEvent,

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -1,6 +1,6 @@
 import Debug from "debug"
 import { useEditEventController } from "lib/hooks/use-edit-event-controller"
-import { useCircuitTitle } from "lib/hooks/use-circuit-title"
+import { useSyncPageTitle } from "lib/hooks/use-sync-page-title"
 import { useEffect } from "react"
 import { RunFrame } from "../RunFrame/RunFrame"
 import { API_BASE } from "./api-base"
@@ -55,7 +55,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
     loadInitialFiles()
   }, [])
 
-  useCircuitTitle()
+  useSyncPageTitle()
 
   const {
     editEventsForRender,

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -56,28 +56,23 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
 
   useEffect(() => {
     if (!document || !fsMap) return
+    const fileKeys = Array.from(fsMap.keys())
+    const entrypoint = guessEntrypoint(fileKeys)
+    const packageJsonContent = fsMap.get("package.json")
 
-    const setCircuitTitle = () => {
-      const fileKeys = Array.from(fsMap.keys())
-      const entrypoint = guessEntrypoint(fileKeys)
-      const packageJsonContent = fsMap.get("package.json")
-
-      try {
-        if (packageJsonContent) {
-          const parsedPackageJson = JSON.parse(packageJsonContent)
-          if (parsedPackageJson?.name) {
-            document.title = parsedPackageJson.name
-            return
-          }
+    try {
+      if (packageJsonContent) {
+        const parsedPackageJson = JSON.parse(packageJsonContent)
+        if (parsedPackageJson?.name) {
+          document.title = parsedPackageJson.name
+          return
         }
-      } catch (e) {}
-
-      if (entrypoint) {
-        document.title = entrypoint
       }
-    }
+    } catch (e) {}
 
-    setCircuitTitle()
+    if (entrypoint) {
+      document.title = entrypoint
+    }
   }, [fsMap])
 
   const {

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -1,5 +1,6 @@
 import Debug from "debug"
 import { useEditEventController } from "lib/hooks/use-edit-event-controller"
+import { useCircuitTitle } from "lib/hooks/use-circuit-title"
 import { useEffect } from "react"
 import { RunFrame } from "../RunFrame/RunFrame"
 import { API_BASE } from "./api-base"
@@ -54,31 +55,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
     loadInitialFiles()
   }, [])
 
-  useEffect(() => {
-    if (!document || !fsMap) return
-
-    const setCircuitTitle = () => {
-      const fileKeys = Array.from(fsMap.keys())
-      const entrypoint = guessEntrypoint(fileKeys)
-      const packageJsonContent = fsMap.get("package.json")
-
-      try {
-        if (packageJsonContent) {
-          const parsedPackageJson = JSON.parse(packageJsonContent)
-          if (parsedPackageJson?.name) {
-            document.title = parsedPackageJson.name
-            return
-          }
-        }
-      } catch (e) {}
-
-      if (entrypoint) {
-        document.title = entrypoint
-      }
-    }
-
-    setCircuitTitle()
-  }, [fsMap])
+  useCircuitTitle()
 
   const {
     editEventsForRender,

--- a/lib/hooks/use-circuit-title.ts
+++ b/lib/hooks/use-circuit-title.ts
@@ -1,0 +1,29 @@
+import { useRunFrameStore } from "lib/components/RunFrameWithApi/store"
+import { guessEntrypoint } from "lib/runner"
+import { useEffect } from "react"
+
+export const useCircuitTitle = () => {
+  const fsMap = useRunFrameStore((s) => s.fsMap)
+
+  useEffect(() => {
+    if (!document || !fsMap) return
+
+    const fileKeys = Array.from(fsMap.keys())
+    const entrypoint = guessEntrypoint(fileKeys)
+    const packageJsonContent = fsMap.get("package.json")
+
+    try {
+      if (packageJsonContent) {
+        const parsedPackageJson = JSON.parse(packageJsonContent)
+        if (parsedPackageJson?.name) {
+          document.title = parsedPackageJson.name
+          return
+        }
+      }
+    } catch (e) {}
+
+    if (entrypoint) {
+      document.title = entrypoint
+    }
+  }, [fsMap])
+}

--- a/lib/hooks/use-sync-page-title.ts
+++ b/lib/hooks/use-sync-page-title.ts
@@ -2,7 +2,7 @@ import { useRunFrameStore } from "lib/components/RunFrameWithApi/store"
 import { guessEntrypoint } from "lib/runner"
 import { useEffect } from "react"
 
-export const useCircuitTitle = () => {
+export const useSyncPageTitle = () => {
   const fsMap = useRunFrameStore((s) => s.fsMap)
 
   useEffect(() => {


### PR DESCRIPTION
/claim [#136](https://github.com/tscircuit/cli/issues/136)
/claim https://github.com/tscircuit/cli/issues/136
Add a useEffect hook to update the document title dynamically using the package.json name or the guessed entrypoint from the file system map. This improves user experience by providing a more descriptive title in the browser tab.