### PR TITLE
Use a globally stored tip in PreviewEmptyState to prevent re-renders from changing content

### DIFF
--- a/lib/components/PreviewEmptyState.tsx
+++ b/lib/components/PreviewEmptyState.tsx
@@ -1,21 +1,16 @@
 import { Button } from "lib/components/ui/button"
 import { getRandomTipForUser } from "lib/utils/getRandomTipForUser"
 import { LightbulbIcon, PlayIcon } from "lucide-react"
-import { useEffect, useState } from "react"
+
+const storedTipHtml: string = getRandomTipForUser()
 
 const PreviewEmptyState = ({ onRunClicked }: { onRunClicked?: () => void }) => {
-  const [tipHtml, setTipHtml] = useState<string>("")
-
-  useEffect(() => {
-    setTipHtml(getRandomTipForUser())
-  }, [])
-
   return (
     <div className="rf-flex rf-flex-col rf-items-center rf-justify-center rf-h-full rf-bg-gray-50 rf-text-gray-500 rf-p-4">
       <LightbulbIcon className="rf-size-14 rf-mb-4" />
       <p className="rf-text-md rf-break-words rf-max-w-xl rf-text-center">
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: its internal function */}
-        Tip: <span dangerouslySetInnerHTML={{ __html: tipHtml }} />
+        Tip: <span dangerouslySetInnerHTML={{ __html: storedTipHtml }} />
       </p>
       {onRunClicked && (
         <Button

--- a/lib/components/PreviewEmptyState.tsx
+++ b/lib/components/PreviewEmptyState.tsx
@@ -1,7 +1,7 @@
 import { Button } from "lib/components/ui/button"
 import { getRandomTipForUser } from "lib/utils/getRandomTipForUser"
 import { LightbulbIcon, PlayIcon } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 
 const PreviewEmptyState = ({ onRunClicked }: { onRunClicked?: () => void }) => {
   const [tipHtml, setTipHtml] = useState<string>("")

--- a/lib/components/PreviewEmptyState.tsx
+++ b/lib/components/PreviewEmptyState.tsx
@@ -2,7 +2,7 @@ import { Button } from "lib/components/ui/button"
 import { getRandomTipForUser } from "lib/utils/getRandomTipForUser"
 import { LightbulbIcon, PlayIcon } from "lucide-react"
 
-const storedTipHtml: string = getRandomTipForUser()
+const tipHtml: string = getRandomTipForUser()
 
 const PreviewEmptyState = ({ onRunClicked }: { onRunClicked?: () => void }) => {
   return (
@@ -10,7 +10,7 @@ const PreviewEmptyState = ({ onRunClicked }: { onRunClicked?: () => void }) => {
       <LightbulbIcon className="rf-size-14 rf-mb-4" />
       <p className="rf-text-md rf-break-words rf-max-w-xl rf-text-center">
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: its internal function */}
-        Tip: <span dangerouslySetInnerHTML={{ __html: storedTipHtml }} />
+        Tip: <span dangerouslySetInnerHTML={{ __html: tipHtml }} />
       </p>
       {onRunClicked && (
         <Button

--- a/lib/components/PreviewEmptyState.tsx
+++ b/lib/components/PreviewEmptyState.tsx
@@ -1,10 +1,14 @@
 import { Button } from "lib/components/ui/button"
 import { getRandomTipForUser } from "lib/utils/getRandomTipForUser"
 import { LightbulbIcon, PlayIcon } from "lucide-react"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 const PreviewEmptyState = ({ onRunClicked }: { onRunClicked?: () => void }) => {
-  const tipHtml = useMemo(() => getRandomTipForUser(), [])
+  const [tipHtml, setTipHtml] = useState<string>("")
+
+  useEffect(() => {
+    setTipHtml(getRandomTipForUser())
+  }, [])
 
   return (
     <div className="rf-flex rf-flex-col rf-items-center rf-justify-center rf-h-full rf-bg-gray-50 rf-text-gray-500 rf-p-4">


### PR DESCRIPTION
Closes: [Issue#957](https://github.com/tscircuit/tscircuit.com/issues/957)
Closes: [Issue#509](https://github.com/tscircuit/runframe/issues/509)
/claim #957


https://github.com/user-attachments/assets/cf5a0516-8ed9-4234-9e8e-47c024f2a0f6

