### PR TITLE
fix error tab not being displayed in the initial run

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -488,7 +488,9 @@ export const CircuitJsonPreview = ({
                 isFullScreen ? "rf-h-[calc(100vh-96px)]" : "rf-h-[620px]",
               )}
             >
-              {circuitJson ? (
+              {(Array.isArray(circuitJsonErrors) &&
+                circuitJsonErrors.length > 0) ||
+              errorMessage ? (
                 <ErrorTabContent
                   code={code}
                   circuitJsonErrors={circuitJsonErrors}


### PR DESCRIPTION
/claim tscircuit/tscircuit.com#1041
/closes tscircuit/tscircuit.com#1041


https://github.com/user-attachments/assets/cbd9c516-e257-4f2b-b404-4eeb7873bcd7

