### PR TITLE
Fix: Display errors correctly on first run failure

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -498,8 +498,8 @@ export const CircuitJsonPreview = ({
                 isFullScreen ? "rf-h-[calc(100vh-96px)]" : "rf-h-[620px]",
               )}
             >
-              {(errorMessage ||
-                (circuitJsonErrors && circuitJsonErrors.length > 0)) ? (
+              {errorMessage ||
+              (circuitJsonErrors && circuitJsonErrors.length > 0) ? (
                 <ErrorTabContent
                   code={code}
                   circuitJsonErrors={circuitJsonErrors}

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -45,7 +45,7 @@ import { capitalizeFirstLetters } from "lib/utils"
 import type { PreviewContentProps, TabId } from "./PreviewContentProps"
 import { version } from "../../../package.json"
 import type { CircuitJson, CircuitJsonError } from "circuit-json"
-import { Object3D } from "three"
+import type { Object3D } from "three"
 
 declare global {
   interface Window {
@@ -498,7 +498,8 @@ export const CircuitJsonPreview = ({
                 isFullScreen ? "rf-h-[calc(100vh-96px)]" : "rf-h-[620px]",
               )}
             >
-              {circuitJson ? (
+              {(errorMessage ||
+                (circuitJsonErrors && circuitJsonErrors.length > 0)) ? (
                 <ErrorTabContent
                   code={code}
                   circuitJsonErrors={circuitJsonErrors}


### PR DESCRIPTION
Issue:

On a fresh application load, if the first execution of user code results in an error, the "Errors" tab fails to display the error details. Instead, it shows the `PreviewEmptyState` component. This happens because the `ErrorTabContent` was only rendered if `circuitJson` was populated, which doesn't seem to occur when the initial run fails.

Fix:

Modified the conditional rendering for the "Errors" tab content in `lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx`. `ErrorTabContent` is now displayed if either the `errorMessage` prop is present or if `circuitJsonErrors` (derived from `circuitJson`) indicates errors. This ensures errors from an initial failed run are shown.