### PR TITLE
Show active async effect name

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -86,6 +86,7 @@ export const CircuitJsonPreview = ({
   showSchematicDebugGrid = false,
   showToggleFullScreen = true,
   defaultToFullScreen = false,
+  activeAsyncEffect,
 }: PreviewContentProps) => {
   useStyles()
 
@@ -164,6 +165,11 @@ export const CircuitJsonPreview = ({
                 {renderLog.lastRenderEvent && (
                   <div className="rf-text-xs rf-text-gray-500">
                     {renderLog.lastRenderEvent?.phase ?? ""}
+                  </div>
+                )}
+                {activeAsyncEffect && (
+                  <div className="rf-text-xs rf-text-gray-500">
+                    {activeAsyncEffect}
                   </div>
                 )}
                 <div className="rf-w-4 rf-h-4 rf-bg-blue-500 rf-opacity-50 rf-rounded-full rf-text-white">

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -67,4 +67,9 @@ export interface PreviewContentProps {
     name: string,
     data: { simpleRouteJson: any },
   ) => void
+
+  /**
+   * Name of the longest running async effect in @tscircuit/core
+   */
+  activeAsyncEffect?: string | null
 }


### PR DESCRIPTION
## Summary
- surface the longest running async effect from `@tscircuit/core`
- update RunFrame to track effect durations and expose a single async effect name
- display the name next to the current phase when progress is shown

## Testing
- `bun run format:check`
- `bun test` *(fails: Test "CircuitWebWorker should handle circuit evaluation" timed out)*

------
https://chatgpt.com/codex/tasks/task_b_683e4c68ab70832eb87d9c55886bfbc1