### PR TITLE
remove color override for schematic viewer

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -405,11 +405,6 @@ export const CircuitJsonPreview = ({
                       onEditEvent?.(ee)
                     }}
                     debugGrid={showSchematicDebugGrid}
-                    colorOverrides={{
-                      schematic: {
-                        background: "transparent",
-                      },
-                    }}
                   />
                 ) : (
                   <PreviewEmptyState onRunClicked={onRunClicked} />


### PR DESCRIPTION
CC @ShiboSoftwareDev , this was supposed to only be active for dark mode or something