### PR TITLE
fix: Clear render logs and progress bar on execution error

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -159,7 +159,7 @@ export const CircuitJsonPreview = ({
               <Loader2 className="rf-w-4 rf-h-4 rf-animate-spin" />
             )}
             {!leftHeaderContent && <div className="rf-flex-grow" />}
-            {renderLog && renderLog.progress !== 1 && (
+            {renderLog && renderLog.progress !== 1 && !errorMessage && (
               <div className="rf-flex rf-items-center rf-gap-2">
                 {renderLog.lastRenderEvent && (
                   <div className="rf-text-xs rf-text-gray-500">

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -238,6 +238,7 @@ export const RunFrame = (props: RunFrameProps) => {
           const message: string = e.message.replace("Error: ", "")
           props.onError?.(e)
           setError({ error: message, stack: e.stack })
+          setRenderLog(null)
           console.error(e)
           return { success: false }
         })
@@ -253,6 +254,7 @@ export const RunFrame = (props: RunFrameProps) => {
         debug("error getting initial circuit json", e)
         props.onError?.(e)
         setError({ error: e.message, stack: e.stack })
+        setRenderLog(null)
         setIsRunning(false)
         return null
       })


### PR DESCRIPTION
The PR fixes the render logs and progress being stuck on error:

![2025-06-04_17-12](https://github.com/user-attachments/assets/2d4fa9fd-53dd-4b98-bb9a-cce7686392a6)