### PR TITLE
Fix copy error button for execution errors

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -60,6 +60,7 @@ export const CircuitJsonPreview = ({
   code,
   onRunClicked = undefined,
   errorMessage,
+  errorStack,
   circuitJson,
   autoroutingGraphics,
   showRightHeaderContent = true,
@@ -492,6 +493,7 @@ export const CircuitJsonPreview = ({
                   code={code}
                   circuitJsonErrors={circuitJsonErrors}
                   errorMessage={errorMessage}
+                  errorStack={errorStack}
                   autoroutingLog={autoroutingLog}
                   onReportAutoroutingLog={onReportAutoroutingLog}
                 />

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -20,6 +20,7 @@ export interface PreviewContentProps {
   onRunClicked?: () => void
   tsxRunTriggerCount?: number
   errorMessage?: string | null
+  errorStack?: string | null
   autoroutingGraphics?: any
   circuitJson: CircuitJson | null
   className?: string

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -419,6 +419,7 @@ export const RunFrame = (props: RunFrameProps) => {
       renderLog={renderLog}
       isRunningCode={isRunning}
       errorMessage={error?.error}
+      errorStack={error?.stack}
       onEditEvent={handleEditEvent}
       editEvents={props.editEvents}
       defaultToFullScreen={props.defaultToFullScreen}


### PR DESCRIPTION
## Summary
- fix copy error button when there are only execution errors
- include stack trace in execution error UI and GitHub issue body
- pass error stack info through CircuitJsonPreview

## Testing
- `bun test` *(fails: CircuitWebWorker tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68431a24fc64832e82061400b45b98f3