### PR TITLE
Improve autorouting bug report naming

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -323,10 +323,15 @@ export const RunFrame = (props: RunFrameProps) => {
     name: string,
     data: { simpleRouteJson: any },
   ) => {
+    let urlPath = ""
+    try {
+      urlPath = window.location.pathname || ""
+    } catch {}
+    const title = urlPath ? `${urlPath} - ${name}` : name
     await registryKy
       .post("autorouting/bug_reports/create", {
         json: {
-          title: name,
+          title,
           simple_route_json: data.simpleRouteJson,
         },
       })


### PR DESCRIPTION
## Summary
- include the current page's URL path when sending autorouting bug reports

## Testing
- `bun x biome check .` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6845f5f27414832ea953be6fd8a29509