### PR TITLE
Use project url for autorouting bug reports

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -382,9 +382,19 @@ export const RunFrame = (props: RunFrameProps) => {
     data: { simpleRouteJson: any },
   ) => {
     let urlPath = ""
-    try {
-      urlPath = window.location.pathname || ""
-    } catch {}
+    const softwareMetadata =
+      Array.isArray(circuitJson) &&
+      (circuitJson as any[]).find(
+        (el) => el.type === "software_project_metadata",
+      )
+    const projectUrl = props.projectUrl ?? softwareMetadata?.project_url
+    if (projectUrl) {
+      try {
+        urlPath = new URL(projectUrl).pathname
+      } catch {
+        urlPath = projectUrl
+      }
+    }
     const title = urlPath ? `${urlPath} - ${name}` : name
     await registryKy
       .post("autorouting/bug_reports/create", {

--- a/lib/components/RunFrame/RunFrameProps.tsx
+++ b/lib/components/RunFrame/RunFrameProps.tsx
@@ -92,6 +92,12 @@ export interface RunFrameProps {
   evalVersion?: string
   forceLatestEvalVersion?: boolean
 
+  /**
+   * Optional project URL whose pathname will be used when
+   * reporting autorouting bugs
+   */
+  projectUrl?: string
+
   onReportAutoroutingLog?: (
     name: string,
     data: { simpleRouteJson: any },


### PR DESCRIPTION
## Summary
- add optional `projectUrl` to `RunFrameProps`
- use projectUrl or `software_project_metadata.project_url` when creating autorouting bug reports

## Testing
- `bun test`
- `bun run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68465b459880832e843a6f0c8586f760