### PR TITLE
Show no errors message in errors tab

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -495,7 +495,8 @@ export const CircuitJsonPreview = ({
               )}
             >
               {errorMessage ||
-              (circuitJsonErrors && circuitJsonErrors.length > 0) ? (
+              (circuitJsonErrors && circuitJsonErrors.length > 0) ||
+              circuitJson ? (
                 <ErrorTabContent
                   code={code}
                   circuitJsonErrors={circuitJsonErrors}

--- a/lib/components/ErrorTabContent/ErrorTabContent.tsx
+++ b/lib/components/ErrorTabContent/ErrorTabContent.tsx
@@ -66,10 +66,10 @@ export const ErrorTabContent = ({
         <div className="rf-mt-4 rf-bg-green-50 rf-rounded-md rf-border rf-border-green-200">
           <div className="rf-p-4">
             <h3 className="rf-text-lg rf-font-semibold rf-text-green-800 rf-mb-3">
-              No Errors 👌
+              No errors or warnings!
             </h3>
             <p className="rf-text-sm rf-text-green-700">
-              Your code is running without any errors.
+              Your code is running without any errors or warnings.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- surface `No errors or warnings!` inside ErrorTabContent when no errors exist
- display ErrorTabContent once circuit JSON is ready so empty state is visible

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68485b6bc3b0832e95b0284fa0f6b93d