### PR TITLE
Fix order quote error messaging

### DIFF
--- a/lib/components/OrderDialog/InitialOrder.tsx
+++ b/lib/components/OrderDialog/InitialOrder.tsx
@@ -82,7 +82,7 @@ export const InitialOrderScreen = ({
   // Check for no_token error
   const isNoTokenError =
     (createOrderQuoteError &&
-      (createOrderQuoteError as any).error_code?.includes("no_token")) ||
+      (createOrderQuoteError as any).error?.error_code?.includes("no_token")) ||
     (orderQuote?.error?.error_code?.includes("no_token") && signIn)
 
   if (!isLoggedIn || isNoTokenError) {
@@ -102,7 +102,8 @@ export const InitialOrderScreen = ({
       {(createOrderQuoteError || orderQuote?.error) && (
         <ErrorMessage
           message={
-            (createOrderQuoteError && (createOrderQuoteError as any).message) ||
+            (createOrderQuoteError &&
+              (createOrderQuoteError as any).error?.message) ||
             orderQuote?.error?.message ||
             "Failed to fetch quotes"
           }


### PR DESCRIPTION
## Summary
- show error message from API in order quote dialog when create call fails

## Testing
- `bun run format:check`
- `node_modules/.bin/tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684a8276f7d88327b976f86760aae318