### PR TITLE
Add AI Review dialog for CLI

### DIFF
--- a/lib/components/AiReviewDialog/AiReviewDialog.tsx
+++ b/lib/components/AiReviewDialog/AiReviewDialog.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "../ui/dialog"
+import { Button } from "../ui/button"
+import { registryKy } from "lib/utils/get-registry-ky"
+import { toast } from "lib/utils/toast"
+import type { CircuitJson } from "circuit-json"
+
+interface AiReview {
+  ai_review_id: string
+  ai_review_text: string | null
+  start_processing_at: string | null
+  finished_processing_at: string | null
+  processing_error: any
+  created_at: string
+  display_status: "pending" | "completed" | "failed"
+}
+
+export interface AiReviewDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  packageName: string
+  fsMap: Map<string, string>
+  circuitJson?: CircuitJson | null
+}
+
+export const AiReviewDialog = ({
+  isOpen,
+  onClose,
+  packageName,
+  fsMap,
+  circuitJson,
+}: AiReviewDialogProps) => {
+  const [aiReviews, setAiReviews] = useState<AiReview[]>([])
+  const [selected, setSelected] = useState<AiReview | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const loadReviews = async () => {
+    setLoading(true)
+    try {
+      const res = await registryKy
+        .get("ai_reviews/list", { searchParams: { package_name: packageName } })
+        .json<{ ai_reviews: AiReview[] }>()
+      setAiReviews(res.ai_reviews)
+    } catch (err) {
+      console.error(err)
+      toast.error("Failed to load AI reviews")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      loadReviews()
+    }
+  }, [isOpen])
+
+  const requestReview = async () => {
+    if (!circuitJson) {
+      toast.error("Need Circuit JSON to Request AI Review")
+      return
+    }
+    try {
+      await registryKy.post("ai_reviews/create", {
+        json: {
+          package_name: packageName,
+          fs_map: Object.fromEntries(fsMap.entries()),
+          circuit_json: circuitJson,
+        },
+      })
+      toast.success("AI review requested")
+      await loadReviews()
+    } catch (err) {
+      console.error(err)
+      toast.error("Failed to request AI review")
+    }
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogContent className="!rf-max-w-xl">
+        <DialogHeader>
+          <DialogTitle>AI Review</DialogTitle>
+        </DialogHeader>
+        {loading ? (
+          <p className="rf-text-sm">Loading...</p>
+        ) : (
+          <div className="rf-flex rf-h-64 rf-gap-4">
+            <div className="rf-w-40 rf-border-r rf-overflow-y-auto">
+              {aiReviews.map((r) => (
+                <button
+                  key={r.ai_review_id}
+                  className={`rf-w-full rf-p-2 rf-text-left rf-text-xs hover:rf-bg-zinc-100 ${
+                    selected?.ai_review_id === r.ai_review_id
+                      ? "rf-bg-zinc-100"
+                      : ""
+                  }`}
+                  onClick={() => setSelected(r)}
+                >
+                  <div>{new Date(r.created_at).toLocaleString()}</div>
+                  <div className="rf-text-[10px]">{r.display_status}</div>
+                </button>
+              ))}
+            </div>
+            <div className="rf-flex-1 rf-overflow-y-auto rf-text-sm rf-p-2">
+              {selected ? (
+                selected.ai_review_text ? (
+                  <pre className="rf-whitespace-pre-wrap">
+                    {selected.ai_review_text}
+                  </pre>
+                ) : (
+                  <p>Review pending...</p>
+                )
+              ) : (
+                <p>Select a review to view its results.</p>
+              )}
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          <Button onClick={requestReview}>Review my Board</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/components/AiReviewDialog/CliAiReviewDialog.tsx
+++ b/lib/components/AiReviewDialog/CliAiReviewDialog.tsx
@@ -1,0 +1,28 @@
+import { AiReviewDialog } from "./AiReviewDialog"
+import { useRunFrameStore } from "../RunFrameWithApi/store"
+import type { FC } from "react"
+
+interface CliAiReviewDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  packageName: string
+}
+
+export const CliAiReviewDialog: FC<CliAiReviewDialogProps> = ({
+  isOpen,
+  onClose,
+  packageName,
+}) => {
+  const fsMap = useRunFrameStore((s) => s.fsMap)
+  const circuitJson = useRunFrameStore((s) => s.circuitJson)
+
+  return (
+    <AiReviewDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      packageName={packageName}
+      fsMap={fsMap}
+      circuitJson={circuitJson}
+    />
+  )
+}

--- a/lib/components/AiReviewDialog/index.ts
+++ b/lib/components/AiReviewDialog/index.ts
@@ -1,0 +1,3 @@
+export * from "./AiReviewDialog"
+export * from "./CliAiReviewDialog"
+export * from "./useAiReviewDialogCli"

--- a/lib/components/AiReviewDialog/useAiReviewDialogCli.tsx
+++ b/lib/components/AiReviewDialog/useAiReviewDialogCli.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react"
+import { CliAiReviewDialog } from "./CliAiReviewDialog"
+
+export const useAiReviewDialogCli = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = () => setIsOpen(true)
+  const close = () => setIsOpen(false)
+
+  const AiReviewDialog = (props: { packageName: string }) => (
+    <CliAiReviewDialog
+      isOpen={isOpen}
+      onClose={close}
+      packageName={props.packageName}
+    />
+  )
+
+  return { isOpen, open, close, AiReviewDialog }
+}

--- a/lib/components/RunFrameForCli/LeftHeader.tsx
+++ b/lib/components/RunFrameForCli/LeftHeader.tsx
@@ -37,6 +37,8 @@ import { toast } from "lib/utils/toast"
 import { Toaster } from "react-hot-toast"
 import { importComponentFromJlcpcb } from "lib/optional-features/importing/import-component-from-jlcpcb"
 import { useOrderDialogCli } from "../OrderDialog/useOrderDialog"
+import { useAiReviewDialogCli } from "../AiReviewDialog/useAiReviewDialogCli"
+import { hasRegistryToken } from "lib/utils/get-registry-ky"
 
 export const RunframeCliLeftHeader = (props: {
   shouldLoadLatestEval: boolean
@@ -62,6 +64,7 @@ export const RunframeCliLeftHeader = (props: {
   const [isError, setIsError] = useState(false)
   const [isExporting, setisExporting] = useState(false)
   const orderDialog = useOrderDialogCli()
+  const aiReviewDialog = useAiReviewDialogCli()
 
   const pushEvent = useRunFrameStore((state) => state.pushEvent)
   const recentEvents = useRunFrameStore((state) => state.recentEvents)
@@ -179,6 +182,18 @@ export const RunframeCliLeftHeader = (props: {
             disabled={isSaving}
           >
             Import
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="rf-text-xs"
+            onSelect={() => {
+              if (!hasRegistryToken()) {
+                toast.error("Need to sign in to request AI review")
+                return
+              }
+              aiReviewDialog.open()
+            }}
+          >
+            AI Review
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger
@@ -325,6 +340,7 @@ export const RunframeCliLeftHeader = (props: {
         }}
       />
       <Toaster position="top-center" reverseOrder={false} />
+      <aiReviewDialog.AiReviewDialog packageName={snippetName ?? ""} />
       <orderDialog.OrderDialog
         isOpen={orderDialog.isOpen}
         onClose={orderDialog.close}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/checks": "^0.0.52",
     "@tscircuit/eval": "^0.0.227",
-    "@tscircuit/fake-snippets": "^0.0.83",
+    "@tscircuit/fake-snippets": "^0.0.84",
     "@tscircuit/math-utils": "^0.0.18",
     "@types/bun": "latest",
     "@types/debug": "^4.1.12",


### PR DESCRIPTION
## Summary
- update `@tscircuit/fake-snippets`
- add new `AiReviewDialog` component with CLI wrapper
- integrate AI Review option in CLI File menu

## Testing
- `npm run format`
- `npm run format:check`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_684ca1f836f8832ea1b14d4a674b55f8