### PR TITLE
Add PostHog analytics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "comlink": "^4.4.2",
         "cssnano": "^7.0.6",
         "marked": "^15.0.12",
+        "posthog-js": "^1.253.4",
         "react-error-boundary": "^6.0.0",
       },
       "devDependencies": {
@@ -1815,7 +1816,7 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "posthog-js": ["posthog-js@1.246.0", "", { "dependencies": { "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-5lN/UMqDfxsLeSnT3LsY4P+eD1H+P9qxgN/iUk473LmhCM7IV8TAfdjJj23nnXk/euGNQtvyINYoD2DG+d4eEw=="],
+    "posthog-js": ["posthog-js@1.253.4", "", { "dependencies": { "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-TukecKZi7Rktb0L2Oq0s9DsXg2/PB/o6sSXgkPpx2oCQt4pzfG4Cco6s92EdOvwijP0cXCmLX7OXG1XJT5LONg=="],
 
     "potpack": ["potpack@1.0.2", "", {}, "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="],
 
@@ -2365,6 +2366,8 @@
 
     "@tscircuit/fake-snippets/jscad-electronics": ["jscad-electronics@0.0.25", "", { "dependencies": { "@tscircuit/footprinter": "^0.0.124", "circuit-json": "^0.0.92" } }, "sha512-XtWBKPi8sXQTVPpodmgMykLO94fec6FTUp0ZVKoQ+LfOFB1Lj3UsMunBzyF0YR0tXAtciJIq6NKLJ+n/B8/ZVw=="],
 
+    "@tscircuit/fake-snippets/posthog-js": ["posthog-js@1.246.0", "", { "dependencies": { "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-5lN/UMqDfxsLeSnT3LsY4P+eD1H+P9qxgN/iUk473LmhCM7IV8TAfdjJj23nnXk/euGNQtvyINYoD2DG+d4eEw=="],
+
     "@tscircuit/pcb-viewer/@tscircuit/core": ["@tscircuit/core@0.0.449", "", { "dependencies": { "@lume/kiwi": "^0.4.3", "css-select": "^5.1.0", "format-si-unit": "^0.0.3", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.31.0", "react-reconciler-18": "npm:react-reconciler@0.29.2", "transformation-matrix": "^2.16.1", "zod": "^3.23.8" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-autolayout": "*", "@tscircuit/schematic-match-adapt": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "schematic-symbols": "*", "typescript": "^5.0.0" } }, "sha512-Gwh0zHmmYWr9bJaBCYaymOiOz/nm0fJ3CMDIKZAbeweO/O4wdrw0SLoJc6Ff8MjZKlh+ozLBF0iIVyiwV/jvsw=="],
 
     "@tscircuit/pcb-viewer/@vitejs/plugin-react": ["@vitejs/plugin-react@4.5.1", "", { "dependencies": { "@babel/core": "^7.26.10", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@rolldown/pluginutils": "1.0.0-beta.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A=="],
@@ -2636,6 +2639,8 @@
     "@tscircuit/fake-snippets/jscad-electronics/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.124", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-sWYTOILmxC6VchCa9877O+wFr6N44Mi0isAEeB/OGnUfjq2iCMgrb0C4scpYDbiStgYqHPk2hAkTFa7Yao6XjA=="],
 
     "@tscircuit/fake-snippets/jscad-electronics/circuit-json": ["circuit-json@0.0.92", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-cEqFxLadAxS+tm7y5/llS4FtqN3QbzjBNubely7vFo8w05sZnGRCcLzZwKL7rC7He1CqqyFynD4MdeL+F/PjBQ=="],
+
+    "@tscircuit/fake-snippets/posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "@tscircuit/pcb-viewer/@tscircuit/core/react-reconciler": ["react-reconciler@0.31.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ=="],
 

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -36,6 +36,7 @@ import { useStyles } from "lib/hooks/use-styles"
 import { useFullscreenBodyScroll } from "lib/hooks/use-fullscreen-body-scroll"
 import { RenderLogViewer } from "../RenderLogViewer/RenderLogViewer"
 import { capitalizeFirstLetters } from "lib/utils"
+import { useErrorTelemetry } from "lib/hooks/use-error-telemetry"
 import type { PreviewContentProps, TabId } from "./PreviewContentProps"
 import { version } from "../../../package.json"
 import type { CircuitJsonError } from "circuit-json"
@@ -108,6 +109,12 @@ export const CircuitJsonPreview = ({
       (e) => (e && "warning_type" in e) || e.type.includes("warning"),
     ) as any
   }, [circuitJson])
+
+  useErrorTelemetry({
+    errorMessage,
+    errorStack,
+    circuitJsonErrors,
+  })
 
   const [activeTab, setActiveTabState] = useState<TabId>(
     defaultActiveTab ?? "pcb",

--- a/lib/hooks/use-error-telemetry.ts
+++ b/lib/hooks/use-error-telemetry.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react"
+import { posthog } from "lib/utils"
+import type { CircuitJsonError } from "circuit-json"
+
+interface UseErrorTelemetryParams {
+  errorMessage?: string
+  errorStack?: string
+  circuitJsonErrors: CircuitJsonError[] | null
+}
+
+export const useErrorTelemetry = ({
+  errorMessage,
+  errorStack,
+  circuitJsonErrors,
+}: UseErrorTelemetryParams) => {
+  useEffect(() => {
+    if (errorMessage) {
+      const err = new Error(errorMessage)
+      if (errorStack) err.stack = errorStack
+      try {
+        posthog.captureException(err)
+      } catch {
+        // ignore analytics errors
+      }
+    }
+  }, [errorMessage, errorStack])
+
+  useEffect(() => {
+    if (circuitJsonErrors && circuitJsonErrors.length > 0) {
+      for (const error of circuitJsonErrors) {
+        const err = new Error(error.message || "Circuit JSON Error")
+        if ((error as any).stack) {
+          ;(err as any).stack = (error as any).stack
+        }
+        try {
+          posthog.captureException(err, { error_type: error.type })
+        } catch {
+          // ignore analytics errors
+        }
+      }
+    }
+  }, [circuitJsonErrors])
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -8,3 +8,5 @@ export function cn(...inputs: ClassValue[]) {
 export const capitalizeFirstLetters = (str: string) => {
   return str.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
 }
+
+export { posthog } from "./posthog"

--- a/lib/utils/posthog.ts
+++ b/lib/utils/posthog.ts
@@ -1,0 +1,15 @@
+import posthog from "posthog-js"
+
+if (
+  !window.location.hostname.includes("localhost") &&
+  !window.location.hostname.includes("127.0.0.1")
+) {
+  if (!(posthog as any).__loaded) {
+    posthog.init("phc_htd8AQjSfVEsFCLQMAiUooG4Q0DKBCjqYuQglc9V3Wo", {
+      api_host: "https://postpig.tscircuit.com",
+      person_profiles: "always",
+    })
+  }
+}
+
+export { posthog }

--- a/package.json
+++ b/package.json
@@ -102,10 +102,11 @@
     "@radix-ui/react-progress": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.2",
-    "react-error-boundary": "^6.0.0",
-    "marked": "^15.0.12",
+    "clsx": "^2.1.1",
     "comlink": "^4.4.2",
     "cssnano": "^7.0.6",
-    "clsx": "^2.1.1"
+    "marked": "^15.0.12",
+    "posthog-js": "^1.253.4",
+    "react-error-boundary": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- initialize PostHog with tscircuit config
- export `posthog` utility
- capture execution and circuit JSON errors in analytics
- extract PostHog telemetry logic into new `useErrorTelemetry` hook

## Testing
- `bun run format`
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68518032da0c832eaa7c0804e7a3b685