### PR TITLE
Fix order dialog z-index

### DIFF
--- a/lib/components/OrderDialog/OrderDialog.tsx
+++ b/lib/components/OrderDialog/OrderDialog.tsx
@@ -34,7 +34,7 @@ export const OrderDialog: FC<OrderDialogProps> = ({
           if (!open) onClose()
         }}
       >
-        <DialogContent className="!rf-max-w-[660px] !rf-p-0">
+        <DialogContent className="!rf-max-w-[660px] !rf-p-0 !rf-z-[101]">
           <div className="rf-relative rf-w-full">
             {stage === "initial" && (
               <InitialOrderScreen


### PR DESCRIPTION
## Summary
- elevate the OrderDialog above other layers by setting z-index to 101

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6852b888a62083278539deda0b829648

Fix this 

![image](https://github.com/user-attachments/assets/2143bb70-49a1-4568-99ee-c4e816342ac0)