### PR TITLE
Display eval version in CircuitJsonPreview dropdown

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -298,6 +298,16 @@ export const CircuitJsonPreview = ({
                           .join(".")}
                       </div>
                     </DropdownMenuItem>
+                    {lastRunEvalVersion && (
+                      <DropdownMenuItem
+                        disabled
+                        className="rf-opacity-60 rf-cursor-default rf-select-none"
+                      >
+                        <div className="rf-pr-2 rf-text-xs rf-text-gray-500">
+                          @tscircuit/eval@{lastRunEvalVersion}
+                        </div>
+                      </DropdownMenuItem>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </TabsList>


### PR DESCRIPTION
## Summary
- show last run eval version below the runframe version in `CircuitJsonPreview`

## Testing
- `bun test tests`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68545bc78c44832ea468c04a71e0ee95