### PR TITLE
Add eval version selector

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -44,6 +44,7 @@ import { useErrorTelemetry } from "lib/hooks/use-error-telemetry"
 import type { PreviewContentProps, TabId } from "./PreviewContentProps"
 import type { CircuitJsonError } from "circuit-json"
 import { useRunnerStore } from "../RunFrame/runner-store/use-runner-store"
+import { version } from "../../../package.json"
 import type { Object3D } from "three"
 
 declare global {
@@ -98,6 +99,7 @@ export const CircuitJsonPreview = ({
   useStyles()
 
   const lastRunEvalVersion = useRunnerStore((s) => s.lastRunEvalVersion)
+  const setLastRunEvalVersion = useRunnerStore((s) => s.setLastRunEvalVersion)
 
   const [evalVersions, setEvalVersions] = useState<string[]>([])
 
@@ -106,7 +108,7 @@ export const CircuitJsonPreview = ({
       .then((res) => res.json())
       .then((data) => {
         if (Array.isArray(data?.versions)) {
-          setEvalVersions(data.versions.slice(0, 20))
+          setEvalVersions(data.versions.slice(1, 21))
         }
       })
       .catch(() => {})
@@ -317,8 +319,8 @@ export const CircuitJsonPreview = ({
                             <DropdownMenuItem
                               key={v}
                               onSelect={() => {
-                                ;(window as any).TSCIRCUIT_LATEST_EVAL_VERSION =
-                                  v
+                                ;(window as any).TSCIRCUIT_LATEST_EVAL_VERSION = v
+                                setLastRunEvalVersion(v)
                               }}
                             >
                               {v}
@@ -327,6 +329,18 @@ export const CircuitJsonPreview = ({
                         </DropdownMenuSubContent>
                       </DropdownMenuPortal>
                     </DropdownMenuSub>
+                    <DropdownMenuItem
+                      disabled
+                      className="rf-opacity-60 rf-cursor-default rf-select-none"
+                    >
+                      <div className="rf-pr-2 rf-text-xs rf-text-gray-500">
+                        @tscircuit/runframe@
+                        {version
+                          .split(".")
+                          .map((part, i) => (i === 2 ? parseInt(part) + 1 : part))
+                          .join(".")}
+                      </div>
+                    </DropdownMenuItem>
                     {lastRunEvalVersion && (
                       <DropdownMenuItem
                         disabled

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -319,7 +319,8 @@ export const CircuitJsonPreview = ({
                             <DropdownMenuItem
                               key={v}
                               onSelect={() => {
-                                ;(window as any).TSCIRCUIT_LATEST_EVAL_VERSION = v
+                                ;(window as any).TSCIRCUIT_LATEST_EVAL_VERSION =
+                                  v
                                 setLastRunEvalVersion(v)
                               }}
                             >
@@ -337,7 +338,9 @@ export const CircuitJsonPreview = ({
                         @tscircuit/runframe@
                         {version
                           .split(".")
-                          .map((part, i) => (i === 2 ? parseInt(part) + 1 : part))
+                          .map((part, i) =>
+                            i === 2 ? parseInt(part) + 1 : part,
+                          )
                           .join(".")}
                       </div>
                     </DropdownMenuItem>

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -29,6 +29,10 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuPortal,
 } from "../ui/dropdown-menu"
 import { Button } from "../ui/button"
 import { PcbViewerWithContainerHeight } from "../PcbViewerWithContainerHeight"
@@ -38,7 +42,6 @@ import { RenderLogViewer } from "../RenderLogViewer/RenderLogViewer"
 import { capitalizeFirstLetters } from "lib/utils"
 import { useErrorTelemetry } from "lib/hooks/use-error-telemetry"
 import type { PreviewContentProps, TabId } from "./PreviewContentProps"
-import { version } from "../../../package.json"
 import type { CircuitJsonError } from "circuit-json"
 import { useRunnerStore } from "../RunFrame/runner-store/use-runner-store"
 import type { Object3D } from "three"
@@ -95,6 +98,19 @@ export const CircuitJsonPreview = ({
   useStyles()
 
   const lastRunEvalVersion = useRunnerStore((s) => s.lastRunEvalVersion)
+
+  const [evalVersions, setEvalVersions] = useState<string[]>([])
+
+  useEffect(() => {
+    fetch("https://data.jsdelivr.com/v1/package/npm/@tscircuit/eval")
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data?.versions)) {
+          setEvalVersions(data.versions.slice(0, 20))
+        }
+      })
+      .catch(() => {})
+  }, [])
 
   const circuitJsonErrors = useMemo<CircuitJsonError[] | null>(() => {
     if (!circuitJson) return null
@@ -291,20 +307,26 @@ export const CircuitJsonPreview = ({
                           )}
                       </DropdownMenuItem>
                     ))}
-                    <DropdownMenuItem
-                      disabled
-                      className="rf-opacity-60 rf-cursor-default rf-select-none"
-                    >
-                      <div className="rf-pr-2 rf-text-xs rf-text-gray-500">
-                        @tscircuit/runframe@
-                        {version
-                          .split(".")
-                          .map((part, i) =>
-                            i === 2 ? parseInt(part) + 1 : part,
-                          )
-                          .join(".")}
-                      </div>
-                    </DropdownMenuItem>
+                    <DropdownMenuSub>
+                      <DropdownMenuSubTrigger className="rf-text-xs">
+                        Eval Version
+                      </DropdownMenuSubTrigger>
+                      <DropdownMenuPortal>
+                        <DropdownMenuSubContent className="rf-*:text-xs">
+                          {evalVersions.map((v) => (
+                            <DropdownMenuItem
+                              key={v}
+                              onSelect={() => {
+                                ;(window as any).TSCIRCUIT_LATEST_EVAL_VERSION =
+                                  v
+                              }}
+                            >
+                              {v}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuSub>
                     {lastRunEvalVersion && (
                       <DropdownMenuItem
                         disabled

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -73,4 +73,9 @@ export interface PreviewContentProps {
     name: string,
     data: { simpleRouteJson: any },
   ) => void
+
+  /**
+   * Enable selecting older @tscircuit/eval versions
+   */
+  allowSelectingVersion?: boolean
 }

--- a/lib/hooks/use-eval-versions.ts
+++ b/lib/hooks/use-eval-versions.ts
@@ -1,0 +1,63 @@
+import { useEffect, useMemo, useState } from "react"
+import { useLocalStorageState } from "./use-local-storage-state"
+import { useRunnerStore } from "lib/components/RunFrame/runner-store/use-runner-store"
+
+export const useEvalVersions = (allowSelecting: boolean) => {
+  const [allVersions, setAllVersions] = useState<string[]>([])
+  const [latest, setLatest] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
+  const [selected, setSelected] = useLocalStorageState<string | null>(
+    "eval-version-selection",
+    null,
+  )
+
+  const setLastRunEvalVersion = useRunnerStore((s) => s.setLastRunEvalVersion)
+  const lastRunEvalVersion = useRunnerStore((s) => s.lastRunEvalVersion)
+
+  useEffect(() => {
+    if (!allowSelecting) return
+    fetch("https://data.jsdelivr.com/v1/package/npm/@tscircuit/eval")
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data?.versions)) {
+          let versions = [...data.versions]
+          if (data.tags?.latest) {
+            setLatest(data.tags.latest)
+            versions = versions.filter((v) => v !== data.tags.latest)
+          }
+          setAllVersions(versions)
+        }
+      })
+      .catch(() => {})
+  }, [allowSelecting])
+
+  useEffect(() => {
+    if (!allowSelecting) return
+    if (selected) {
+      window.TSCIRCUIT_LATEST_EVAL_VERSION = selected
+      setLastRunEvalVersion(selected)
+    } else if (latest) {
+      window.TSCIRCUIT_LATEST_EVAL_VERSION = latest
+      setLastRunEvalVersion(latest)
+    }
+  }, [allowSelecting, selected, latest])
+
+  const filtered = useMemo(
+    () => allVersions.filter((v) => v.includes(search)).slice(0, 50),
+    [allVersions, search],
+  )
+
+  const selectVersion = (v: string | null) => {
+    setSelected(v)
+    setSearch("")
+  }
+
+  return {
+    versions: filtered,
+    latestVersion: latest,
+    lastRunEvalVersion,
+    search,
+    setSearch,
+    selectVersion,
+  }
+}


### PR DESCRIPTION
Closes https://github.com/tscircuit/runframe/issues/863

https://github.com/user-attachments/assets/d4cbbb25-3ab0-41a0-9f98-eb154965837b

## Summary
- fetch list of `@tscircuit/eval` versions and show a submenu
- remove runframe version line in dropdown

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68767daa9494832c9413fc2d7e21fc3e