### PR TITLE
Add `availableTabs` and `defaultTab` to RunFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ circuit.add(
     onRenderingFinished={({ circuitJson }) => void}
     onRenderEvent={(event) => void}
     onError={(error) => void}
+    availableTabs={["pcb", "schematic", "cad"]}
+    defaultTab="pcb"
   />
 )
 ```

--- a/examples/example22-dynamic-tabs.fixture.tsx
+++ b/examples/example22-dynamic-tabs.fixture.tsx
@@ -1,0 +1,79 @@
+import { RunFrame } from "lib/components/RunFrame/RunFrame"
+import type { TabId } from "lib/components/CircuitJsonPreview/PreviewContentProps"
+import React, { useState } from "react"
+
+export default () => {
+  const allTabs: TabId[] = [
+    "pcb",
+    "schematic",
+    "assembly",
+    "cad",
+    "bom",
+    "circuit_json",
+    "errors",
+    "render_log",
+  ]
+  const [availableTabs, setAvailableTabs] = useState<TabId[]>([
+    "pcb",
+    "schematic",
+    "cad",
+  ])
+  const [defaultTab, setDefaultTab] = useState<TabId>("pcb")
+
+  const toggleTab = (tab: TabId) => {
+    setAvailableTabs((prev) =>
+      prev.includes(tab) ? prev.filter((t) => t !== tab) : [...prev, tab],
+    )
+  }
+
+  return (
+    <div className="rf-space-y-4 rf-p-4">
+      <div>
+        <h3 className="rf-font-semibold rf-mb-2">Configure Tabs</h3>
+        <div className="rf-flex rf-flex-wrap rf-gap-2">
+          {allTabs.map((tab) => (
+            <label key={tab} className="rf-flex rf-items-center rf-space-x-1">
+              <input
+                type="checkbox"
+                checked={availableTabs.includes(tab)}
+                onChange={() => toggleTab(tab)}
+              />
+              <span>{tab}</span>
+            </label>
+          ))}
+        </div>
+        <div className="rf-mt-2">
+          <label className="rf-mr-2">Default Tab:</label>
+          <select
+            value={defaultTab}
+            onChange={(e) => setDefaultTab(e.target.value as TabId)}
+          >
+            {availableTabs.map((tab) => (
+              <option key={tab} value={tab}>
+                {tab}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <RunFrame
+        fsMap={{
+          "main.tsx": `
+import { Fragment } from "react"
+
+circuit.add(
+  <board width="10mm" height="10mm">
+    <resistor name="R1" resistance="1k" footprint="0402" />
+    <trace from=".R1 > .pin1" to=".R1 > .pin2" />
+  </board>
+)
+`,
+        }}
+        entrypoint="main.tsx"
+        availableTabs={availableTabs}
+        defaultTab={defaultTab}
+        showRunButton
+      />
+    </div>
+  )
+}

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -86,6 +86,8 @@ export const CircuitJsonPreview = ({
   onEditEvent,
   editEvents,
   defaultActiveTab,
+  defaultTab,
+  availableTabs,
   autoRotate3dViewerDisabled,
   showSchematicDebugGrid = false,
   showToggleFullScreen = true,
@@ -117,7 +119,7 @@ export const CircuitJsonPreview = ({
   })
 
   const [activeTab, setActiveTabState] = useState<TabId>(
-    defaultActiveTab ?? "pcb",
+    defaultActiveTab ?? defaultTab ?? availableTabs?.[0] ?? "pcb",
   )
   const [lastActiveTab, setLastActiveTab] = useState<TabId | null>(null)
   const [isFullScreen, setIsFullScreen] = useState(defaultToFullScreen)
@@ -149,7 +151,13 @@ export const CircuitJsonPreview = ({
       circuitJson &&
       !errorMessage
     ) {
-      setActiveTab(lastActiveTab ?? defaultActiveTab ?? "pcb")
+      setActiveTab(
+        lastActiveTab ??
+          defaultActiveTab ??
+          defaultTab ??
+          availableTabs?.[0] ??
+          "pcb",
+      )
     }
   }, [circuitJson])
 
@@ -212,45 +220,54 @@ export const CircuitJsonPreview = ({
             {showRightHeaderContent && (
               <TabsList>
                 {showCodeTab && <TabsTrigger value="code">Code</TabsTrigger>}
-                <TabsTrigger value="pcb" className="rf-whitespace-nowrap">
-                  {circuitJson && (
-                    <span
-                      className={cn(
-                        "rf-inline-flex rf-items-center rf-justify-center rf-w-2 rf-h-2 rf-mr-1 rf-text-xs rf-font-bold rf-text-white rf-rounded-full",
-                        !hasCodeChangedSinceLastRun
-                          ? "rf-bg-blue-500"
-                          : "rf-bg-gray-500",
-                      )}
-                    />
-                  )}
-                  PCB
-                </TabsTrigger>
-                <TabsTrigger value="schematic" className="rf-whitespace-nowrap">
-                  {circuitJson && (
-                    <span
-                      className={cn(
-                        "rf-inline-flex rf-items-center rf-justify-center rf-w-2 rf-h-2 rf-mr-1 rf-text-xs rf-font-bold rf-text-white rf-rounded-full",
-                        !hasCodeChangedSinceLastRun
-                          ? "rf-bg-blue-500"
-                          : "rf-bg-gray-500",
-                      )}
-                    />
-                  )}
-                  Schematic
-                </TabsTrigger>
-                <TabsTrigger value="cad">
-                  {circuitJson && (
-                    <span
-                      className={cn(
-                        "inline-flex items-center justify-center w-2 h-2 mr-1 text-xs font-bold text-white rounded-full",
-                        !hasCodeChangedSinceLastRun
-                          ? "rf-bg-blue-500"
-                          : "rf-bg-gray-500",
-                      )}
-                    />
-                  )}
-                  3D
-                </TabsTrigger>
+                {!availableTabs || availableTabs.includes("pcb") ? (
+                  <TabsTrigger value="pcb" className="rf-whitespace-nowrap">
+                    {circuitJson && (
+                      <span
+                        className={cn(
+                          "rf-inline-flex rf-items-center rf-justify-center rf-w-2 rf-h-2 rf-mr-1 rf-text-xs rf-font-bold rf-text-white rf-rounded-full",
+                          !hasCodeChangedSinceLastRun
+                            ? "rf-bg-blue-500"
+                            : "rf-bg-gray-500",
+                        )}
+                      />
+                    )}
+                    PCB
+                  </TabsTrigger>
+                ) : null}
+                {!availableTabs || availableTabs.includes("schematic") ? (
+                  <TabsTrigger
+                    value="schematic"
+                    className="rf-whitespace-nowrap"
+                  >
+                    {circuitJson && (
+                      <span
+                        className={cn(
+                          "rf-inline-flex rf-items-center rf-justify-center rf-w-2 rf-h-2 rf-mr-1 rf-text-xs rf-font-bold rf-text-white rf-rounded-full",
+                          !hasCodeChangedSinceLastRun
+                            ? "rf-bg-blue-500"
+                            : "rf-bg-gray-500",
+                        )}
+                      />
+                    )}
+                    Schematic
+                  </TabsTrigger>
+                ) : null}
+                {!availableTabs || availableTabs.includes("cad") ? (
+                  <TabsTrigger value="cad">
+                    {circuitJson && (
+                      <span
+                        className={cn(
+                          "inline-flex items-center justify-center w-2 h-2 mr-1 text-xs font-bold text-white rounded-full",
+                          !hasCodeChangedSinceLastRun
+                            ? "rf-bg-blue-500"
+                            : "rf-bg-gray-500",
+                        )}
+                      />
+                    )}
+                    3D
+                  </TabsTrigger>
+                ) : null}
                 {!["pcb", "cad", "schematic"].includes(activeTab) && (
                   <TabsTrigger value={activeTab}>
                     {capitalizeFirstLetters(activeTab)}
@@ -267,30 +284,36 @@ export const CircuitJsonPreview = ({
                     </div>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent className="rf-*:text-xs">
-                    {dropdownMenuItems.map((item) => (
-                      <DropdownMenuItem
-                        key={item}
-                        onSelect={() => setActiveTab(item as TabId)}
-                      >
-                        {activeTab !== item && (
-                          <Circle className="rf-w-3 rf-h-3 rf-opacity-30" />
-                        )}
-                        {activeTab === item && (
-                          <CheckIcon className="rf-w-3 rf-h-3" />
-                        )}
-                        <div className="rf-pr-2">
-                          {capitalizeFirstLetters(item)}
-                        </div>
-                        {item === "errors" &&
-                          ((circuitJsonErrors &&
-                            circuitJsonErrors.length > 0) ||
-                            errorMessage) && (
-                            <span className="rf-inline-flex rf-items-center rf-justify-center rf-w-3 rf-h-3 rf-ml-2 rf-text-[8px] rf-font-bold rf-text-white rf-bg-red-500 rf-rounded-full">
-                              {errorMessage ? 1 : circuitJsonErrors?.length}
-                            </span>
+                    {dropdownMenuItems
+                      .filter(
+                        (item) =>
+                          !availableTabs ||
+                          availableTabs.includes(item as TabId),
+                      )
+                      .map((item) => (
+                        <DropdownMenuItem
+                          key={item}
+                          onSelect={() => setActiveTab(item as TabId)}
+                        >
+                          {activeTab !== item && (
+                            <Circle className="rf-w-3 rf-h-3 rf-opacity-30" />
                           )}
-                      </DropdownMenuItem>
-                    ))}
+                          {activeTab === item && (
+                            <CheckIcon className="rf-w-3 rf-h-3" />
+                          )}
+                          <div className="rf-pr-2">
+                            {capitalizeFirstLetters(item)}
+                          </div>
+                          {item === "errors" &&
+                            ((circuitJsonErrors &&
+                              circuitJsonErrors.length > 0) ||
+                              errorMessage) && (
+                              <span className="rf-inline-flex rf-items-center rf-justify-center rf-w-3 rf-h-3 rf-ml-2 rf-text-[8px] rf-font-bold rf-text-white rf-bg-red-500 rf-rounded-full">
+                                {errorMessage ? 1 : circuitJsonErrors?.length}
+                              </span>
+                            )}
+                        </DropdownMenuItem>
+                      ))}
                     <DropdownMenuItem
                       disabled
                       className="rf-opacity-60 rf-cursor-default rf-select-none"
@@ -337,224 +360,239 @@ export const CircuitJsonPreview = ({
               <div className="rf-h-full">{codeTabContent}</div>
             </TabsContent>
           )}
-          <TabsContent value="pcb">
-            <div
-              className={cn(
-                "rf-overflow-hidden",
-                isFullScreen ? "rf-h-[calc(100vh-52px)]" : "rf-h-full",
-              )}
-            >
-              <ErrorBoundary
-                fallbackRender={({ error }: { error: Error }) => (
-                  <div className="rf-mt-4 rf-bg-red-50 rf-rounded-md rf-border rf-border-red-200">
-                    <div className="rf-p-4">
-                      <h3 className="rf-text-lg rf-font-semibold rf-text-red-800 rf-mb-3">
-                        Error loading PCB viewer
-                      </h3>
-                      <p className="rf-text-xs rf-font-mono rf-whitespace-pre-wrap rf-text-red-600 rf-mt-2">
-                        {error?.message || "An unknown error occurred"}
-                      </p>
-                    </div>
-                  </div>
+          {(!availableTabs || availableTabs.includes("pcb")) && (
+            <TabsContent value="pcb">
+              <div
+                className={cn(
+                  "rf-overflow-hidden",
+                  isFullScreen ? "rf-h-[calc(100vh-52px)]" : "rf-h-full",
                 )}
               >
-                {circuitJson ? (
-                  <PcbViewerWithContainerHeight
-                    focusOnHover={false}
-                    circuitJson={circuitJson}
-                    debugGraphics={autoroutingGraphics}
-                    containerClassName={cn(
-                      "rf-h-full rf-w-full",
-                      isFullScreen
-                        ? "rf-min-h-[calc(100vh-240px)]"
-                        : "rf-min-h-[620px]",
-                    )}
-                    onEditEventsChanged={(editEvents) => {
-                      if (onEditEvent) {
-                        editEvents.forEach((e) => onEditEvent(e))
-                      }
-                    }}
-                    // onEditEventsChanged={(editEvents) => {
-                    //   if (editEvents.some((editEvent) => editEvent.in_progress))
-                    //     return
-                    //   // Update state with new edit events
-                    //   const newManualEditsFileContent = applyPcbEditEvents({
-                    //     editEvents,
-                    //     circuitJson,
-                    //     manualEditsFileContent,
-                    //   })
-                    //   onManualEditsFileContentChange?.(
-                    //     JSON.stringify(newManualEditsFileContent, null, 2),
-                    //   )
-                    // }}
-                  />
-                ) : (
-                  <PreviewEmptyState onRunClicked={onRunClicked} />
-                )}
-              </ErrorBoundary>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="assembly">
-            <div
-              className={cn(
-                "rf-overflow-auto",
-                isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
-              )}
-            >
-              <ErrorBoundary fallback={<div>Error loading Assembly</div>}>
-                {circuitJson ? (
-                  <AssemblyViewer
-                    circuitJson={circuitJson}
-                    containerStyle={{
-                      height: "100%",
-                    }}
-                    editingEnabled
-                    debugGrid
-                  />
-                ) : (
-                  <PreviewEmptyState onRunClicked={onRunClicked} />
-                )}
-              </ErrorBoundary>
-            </div>
-          </TabsContent>
-          <TabsContent value="schematic">
-            <div
-              className={cn(
-                "rf-overflow-auto rf-bg-white",
-                isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
-              )}
-            >
-              <ErrorBoundary
-                fallbackRender={({ error }: { error: Error }) => (
-                  <div className="rf-mt-4 rf-bg-red-50 rf-rounded-md rf-border rf-border-red-200">
-                    <div className="rf-p-4">
-                      <h3 className="rf-text-lg rf-font-semibold rf-text-red-800 rf-mb-3">
-                        Error loading Schematic
-                      </h3>
-                      <p className="rf-text-xs rf-font-mono rf-whitespace-pre-wrap rf-text-red-600 rf-mt-2">
-                        {error?.message || "An unknown error occurred"}
-                      </p>
+                <ErrorBoundary
+                  fallbackRender={({ error }: { error: Error }) => (
+                    <div className="rf-mt-4 rf-bg-red-50 rf-rounded-md rf-border rf-border-red-200">
+                      <div className="rf-p-4">
+                        <h3 className="rf-text-lg rf-font-semibold rf-text-red-800 rf-mb-3">
+                          Error loading PCB viewer
+                        </h3>
+                        <p className="rf-text-xs rf-font-mono rf-whitespace-pre-wrap rf-text-red-600 rf-mt-2">
+                          {error?.message || "An unknown error occurred"}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                )}
-              >
-                {circuitJson ? (
-                  <SchematicViewer
-                    circuitJson={circuitJson}
-                    containerStyle={{
-                      height: "100%",
-                    }}
-                    editingEnabled
-                    onEditEvent={(ee) => {
-                      onEditEvent?.(ee)
-                    }}
-                    debugGrid={showSchematicDebugGrid}
-                  />
-                ) : (
-                  <PreviewEmptyState onRunClicked={onRunClicked} />
-                )}
-              </ErrorBoundary>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="cad">
-            <div
-              className={cn(
-                "rf-overflow-auto",
-                isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
-              )}
-            >
-              <ErrorBoundary FallbackComponent={ErrorFallback}>
-                {circuitJson ? (
-                  <CadViewer
-                    ref={setCadViewerRef}
-                    circuitJson={circuitJson as any}
-                    autoRotateDisabled={autoRotate3dViewerDisabled}
-                  />
-                ) : (
-                  <PreviewEmptyState onRunClicked={onRunClicked} />
-                )}
-              </ErrorBoundary>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="bom">
-            <div
-              className={cn(
-                "rf-overflow-auto",
-                isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
-              )}
-            >
-              <ErrorBoundary
-                fallbackRender={({ error }: { error: Error }) => (
-                  <div className="rf-mt-4 rf-bg-red-50 rf-rounded-md rf-border rf-border-red-200">
-                    <div className="rf-p-4">
-                      <h3 className="rf-text-lg rf-font-semibold rf-text-red-800 rf-mb-3">
-                        Error loading Bill of Materials
-                      </h3>
-                      <p className="rf-text-xs rf-font-mono rf-whitespace-pre-wrap rf-text-red-600 rf-mt-2">
-                        {error?.message || "An unknown error occurred"}
-                      </p>
-                    </div>
-                  </div>
-                )}
-              >
-                {circuitJson ? (
-                  <BomTable circuitJson={circuitJson} />
-                ) : (
-                  <PreviewEmptyState onRunClicked={onRunClicked} />
-                )}
-              </ErrorBoundary>
-            </div>
-          </TabsContent>
-          <TabsContent value="circuit_json">
-            <div
-              className={cn(
-                "rf-overflow-auto",
-                isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
-              )}
-            >
-              <ErrorBoundary fallback={<div>Error loading JSON viewer</div>}>
-                {circuitJson ? (
-                  <CircuitJsonTableViewer elements={circuitJson as any} />
-                ) : (
-                  <PreviewEmptyState onRunClicked={onRunClicked} />
-                )}
-              </ErrorBoundary>
-            </div>
-          </TabsContent>
-          <TabsContent value="errors">
-            <div
-              className={cn(
-                "rf-overflow-auto",
-                isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
-              )}
-            >
-              {errorMessage ||
-              (circuitJsonErrors && circuitJsonErrors.length > 0) ||
-              circuitJson ? (
-                <ErrorTabContent
-                  code={code}
-                  circuitJsonErrors={circuitJsonErrors}
-                  circuitJsonWarnings={circuitJsonWarnings}
-                  errorMessage={errorMessage}
-                  errorStack={errorStack}
-                  circuitJson={circuitJson}
-                  evalVersion={lastRunEvalVersion}
-                  autoroutingLog={autoroutingLog}
-                  onReportAutoroutingLog={onReportAutoroutingLog}
-                />
-              ) : (
-                <PreviewEmptyState onRunClicked={onRunClicked} />
-              )}
-            </div>
-          </TabsContent>
-          {showRenderLogTab && (
-            <TabsContent value="render_log">
-              <RenderLogViewer renderLog={renderLog} />
+                  )}
+                >
+                  {circuitJson ? (
+                    <PcbViewerWithContainerHeight
+                      focusOnHover={false}
+                      circuitJson={circuitJson}
+                      debugGraphics={autoroutingGraphics}
+                      containerClassName={cn(
+                        "rf-h-full rf-w-full",
+                        isFullScreen
+                          ? "rf-min-h-[calc(100vh-240px)]"
+                          : "rf-min-h-[620px]",
+                      )}
+                      onEditEventsChanged={(editEvents) => {
+                        if (onEditEvent) {
+                          editEvents.forEach((e) => onEditEvent(e))
+                        }
+                      }}
+                      // onEditEventsChanged={(editEvents) => {
+                      //   if (editEvents.some((editEvent) => editEvent.in_progress))
+                      //     return
+                      //   // Update state with new edit events
+                      //   const newManualEditsFileContent = applyPcbEditEvents({
+                      //     editEvents,
+                      //     circuitJson,
+                      //     manualEditsFileContent,
+                      //   })
+                      //   onManualEditsFileContentChange?.(
+                      //     JSON.stringify(newManualEditsFileContent, null, 2),
+                      //   )
+                      // }}
+                    />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
             </TabsContent>
           )}
+
+          {(!availableTabs || availableTabs.includes("assembly")) && (
+            <TabsContent value="assembly">
+              <div
+                className={cn(
+                  "rf-overflow-auto",
+                  isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                <ErrorBoundary fallback={<div>Error loading Assembly</div>}>
+                  {circuitJson ? (
+                    <AssemblyViewer
+                      circuitJson={circuitJson}
+                      containerStyle={{
+                        height: "100%",
+                      }}
+                      editingEnabled
+                      debugGrid
+                    />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
+            </TabsContent>
+          )}
+          {(!availableTabs || availableTabs.includes("schematic")) && (
+            <TabsContent value="schematic">
+              <div
+                className={cn(
+                  "rf-overflow-auto rf-bg-white",
+                  isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                <ErrorBoundary
+                  fallbackRender={({ error }: { error: Error }) => (
+                    <div className="rf-mt-4 rf-bg-red-50 rf-rounded-md rf-border rf-border-red-200">
+                      <div className="rf-p-4">
+                        <h3 className="rf-text-lg rf-font-semibold rf-text-red-800 rf-mb-3">
+                          Error loading Schematic
+                        </h3>
+                        <p className="rf-text-xs rf-font-mono rf-whitespace-pre-wrap rf-text-red-600 rf-mt-2">
+                          {error?.message || "An unknown error occurred"}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                >
+                  {circuitJson ? (
+                    <SchematicViewer
+                      circuitJson={circuitJson}
+                      containerStyle={{
+                        height: "100%",
+                      }}
+                      editingEnabled
+                      onEditEvent={(ee) => {
+                        onEditEvent?.(ee)
+                      }}
+                      debugGrid={showSchematicDebugGrid}
+                    />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
+            </TabsContent>
+          )}
+
+          {(!availableTabs || availableTabs.includes("cad")) && (
+            <TabsContent value="cad">
+              <div
+                className={cn(
+                  "rf-overflow-auto",
+                  isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                <ErrorBoundary FallbackComponent={ErrorFallback}>
+                  {circuitJson ? (
+                    <CadViewer
+                      ref={setCadViewerRef}
+                      circuitJson={circuitJson as any}
+                      autoRotateDisabled={autoRotate3dViewerDisabled}
+                    />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
+            </TabsContent>
+          )}
+
+          {(!availableTabs || availableTabs.includes("bom")) && (
+            <TabsContent value="bom">
+              <div
+                className={cn(
+                  "rf-overflow-auto",
+                  isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                <ErrorBoundary
+                  fallbackRender={({ error }: { error: Error }) => (
+                    <div className="rf-mt-4 rf-bg-red-50 rf-rounded-md rf-border rf-border-red-200">
+                      <div className="rf-p-4">
+                        <h3 className="rf-text-lg rf-font-semibold rf-text-red-800 rf-mb-3">
+                          Error loading Bill of Materials
+                        </h3>
+                        <p className="rf-text-xs rf-font-mono rf-whitespace-pre-wrap rf-text-red-600 rf-mt-2">
+                          {error?.message || "An unknown error occurred"}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                >
+                  {circuitJson ? (
+                    <BomTable circuitJson={circuitJson} />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
+            </TabsContent>
+          )}
+          {(!availableTabs || availableTabs.includes("circuit_json")) && (
+            <TabsContent value="circuit_json">
+              <div
+                className={cn(
+                  "rf-overflow-auto",
+                  isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                <ErrorBoundary fallback={<div>Error loading JSON viewer</div>}>
+                  {circuitJson ? (
+                    <CircuitJsonTableViewer elements={circuitJson as any} />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
+            </TabsContent>
+          )}
+          {(!availableTabs || availableTabs.includes("errors")) && (
+            <TabsContent value="errors">
+              <div
+                className={cn(
+                  "rf-overflow-auto",
+                  isFullScreen ? "rf-h-screen" : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                {errorMessage ||
+                (circuitJsonErrors && circuitJsonErrors.length > 0) ||
+                circuitJson ? (
+                  <ErrorTabContent
+                    code={code}
+                    circuitJsonErrors={circuitJsonErrors}
+                    circuitJsonWarnings={circuitJsonWarnings}
+                    errorMessage={errorMessage}
+                    errorStack={errorStack}
+                    circuitJson={circuitJson}
+                    evalVersion={lastRunEvalVersion}
+                    autoroutingLog={autoroutingLog}
+                    onReportAutoroutingLog={onReportAutoroutingLog}
+                  />
+                ) : (
+                  <PreviewEmptyState onRunClicked={onRunClicked} />
+                )}
+              </div>
+            </TabsContent>
+          )}
+          {showRenderLogTab &&
+            (!availableTabs || availableTabs.includes("render_log")) && (
+              <TabsContent value="render_log">
+                <RenderLogViewer renderLog={renderLog} />
+              </TabsContent>
+            )}
         </Tabs>
       </div>
     </div>

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -53,6 +53,16 @@ export interface PreviewContentProps {
 
   defaultActiveTab?: TabId
 
+  /**
+   * Alias for defaultActiveTab
+   */
+  defaultTab?: TabId
+
+  /**
+   * Tabs to display. Defaults to all
+   */
+  availableTabs?: TabId[]
+
   renderLog?: RenderLog | null
 
   /**

--- a/lib/components/CircuitJsonPreviewStandalone/standalone-preview.tsx
+++ b/lib/components/CircuitJsonPreviewStandalone/standalone-preview.tsx
@@ -10,6 +10,8 @@ declare global {
     CIRCUIT_JSON_PREVIEW_PROPS?: {
       autoRotate3dViewerDisabled?: boolean
       defaultActiveTab?: TabId
+      defaultTab?: TabId
+      availableTabs?: TabId[]
       showRightHeaderContent?: boolean
     }
   }

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -152,7 +152,7 @@ export const RunFrame = (props: RunFrameProps) => {
   const [renderLog, setRenderLog] = useState<RenderLog | null>(null)
   const [autoroutingLog, setAutoroutingLog] = useState<Record<string, any>>({})
   const [activeTab, setActiveTab] = useState<TabId>(
-    props.defaultActiveTab ?? "pcb",
+    props.defaultActiveTab ?? props.defaultTab ?? "pcb",
   )
   useEffect(() => {
     if (props.debug) Debug.enable("run-frame*")
@@ -452,7 +452,9 @@ export const RunFrame = (props: RunFrameProps) => {
   return (
     <CircuitJsonPreview
       code={fsMap.get(props.entrypoint ?? props.mainComponentPath)}
-      defaultActiveTab={props.defaultActiveTab}
+      defaultActiveTab={props.defaultActiveTab ?? props.defaultTab}
+      defaultTab={props.defaultTab}
+      availableTabs={props.availableTabs}
       showToggleFullScreen={props.showToggleFullScreen}
       autoroutingGraphics={autoroutingGraphics}
       autoroutingLog={autoroutingLog}

--- a/lib/components/RunFrame/RunFrameProps.tsx
+++ b/lib/components/RunFrame/RunFrameProps.tsx
@@ -87,6 +87,16 @@ export interface RunFrameProps {
 
   defaultActiveTab?: TabId
 
+  /**
+   * Alias for defaultActiveTab
+   */
+  defaultTab?: TabId
+
+  /**
+   * Tabs to display. Defaults to all
+   */
+  availableTabs?: TabId[]
+
   evalWebWorkerBlobUrl?: string
 
   evalVersion?: string


### PR DESCRIPTION

<img width="4176" height="1040" alt="image" src="https://github.com/user-attachments/assets/fcf06052-6086-4799-bee9-859c3b52ce5b" />


## Summary
- add `availableTabs` and `defaultTab` props to RunFrame
- forward props to CircuitJsonPreview
- support availableTabs/defaultTab in preview and standalone preview
- document the new props in README

## Testing
- `bun run format`
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_687723c70b7c832ea79444a0cf27471b