### PR TITLE
feat: add support to fetch main component path from window explicitly to RunFrameWithApi

### DIFF
--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -51,6 +51,8 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
   const fsMap = useRunFrameStore((s) => s.fsMap)
   const circuitJson = useRunFrameStore((s) => s.circuitJson)
 
+  const mainComponentPath = window?.TSCIRCUIT_MAIN_COMPONENT_PATH
+
   useEffect(() => {
     loadInitialFiles()
   }, [])
@@ -85,6 +87,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
       leftHeaderContent={leftHeaderContent}
       defaultToFullScreen={props.defaultToFullScreen}
       showToggleFullScreen={props.showToggleFullScreen}
+      mainComponentPath={mainComponentPath}
       onInitialRender={() => {
         debug("onInitialRender / markRenderStarted")
         markRenderStarted()

--- a/lib/components/RunFrameWithApi/types.ts
+++ b/lib/components/RunFrameWithApi/types.ts
@@ -128,5 +128,10 @@ declare global {
      * The version of the eval package to use
      */
     TSCIRCUIT_LATEST_EVAL_VERSION: string | null
+    /**
+     * The path to the main component that should be rendered. If not provided,
+     * the default component from the entry point will be used.
+     */
+    TSCIRCUIT_MAIN_COMPONENT_PATH?: string
   }
 }


### PR DESCRIPTION
… 

### Part 1 pr for https://github.com/tscircuit/cli/issues/174

- Introduced `mainComponentPath` to the RunFrameWithApi component, allowing for a customizable main component to be rendered.
- Updated global types to include `TSCIRCUIT_MAIN_COMPONENT_PATH` for better flexibility in component rendering.