### PR TITLE
Support src on tscircuit-tsx scripts

### DIFF
--- a/lib/components/RunFrameWithApi/standalone.tsx
+++ b/lib/components/RunFrameWithApi/standalone.tsx
@@ -13,33 +13,43 @@ const ensureRoot = () => {
   return el
 }
 
-const loadScriptsAsFsMap = () => {
+const loadScriptsAsFsMap = async () => {
   const scripts = Array.from(
     document.querySelectorAll<HTMLScriptElement>(
       "script[type='tscircuit-tsx']",
     ),
   )
   const fsMap = new Map<string, string>()
-  scripts.forEach((script, idx) => {
-    const path =
-      script.dataset.path ||
-      script.getAttribute("data-file-path") ||
-      `script${idx ? idx + 1 : ""}.tsx`
-    fsMap.set(path, script.textContent || "")
-  })
+  await Promise.all(
+    scripts.map(async (script, idx) => {
+      const path =
+        script.dataset.path ||
+        script.getAttribute("data-file-path") ||
+        `script${idx ? idx + 1 : ""}.tsx`
+
+      if (script.src) {
+        const response = await fetch(script.src)
+        const text = await response.text()
+        fsMap.set(path, text)
+      } else {
+        fsMap.set(path, script.textContent || "")
+      }
+    }),
+  )
   return { fsMap }
 }
 
 const root = createRoot(ensureRoot())
-
-// @ts-ignore
-if (window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI) {
-  root.render(<RunFrameForCli />)
-} else {
-  const { fsMap } = loadScriptsAsFsMap()
-  if (fsMap.size > 0) {
-    root.render(<RunFrame fsMap={fsMap} />)
+;(async () => {
+  // @ts-ignore
+  if (window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI) {
+    root.render(<RunFrameForCli />)
   } else {
-    root.render(<RunFrameWithApi />)
+    const { fsMap } = await loadScriptsAsFsMap()
+    if (fsMap.size > 0) {
+      root.render(<RunFrame fsMap={fsMap} />)
+    } else {
+      root.render(<RunFrameWithApi />)
+    }
   }
-}
+})()


### PR DESCRIPTION
## Summary
- allow `script[type="tscircuit-tsx"]` tags to load from `src`

## Testing
- `bun test`
- `bun run format:check`


------
https://chatgpt.com/codex/tasks/task_b_687eefdecb8c8327a08268713d6a3726