### PR TITLE
Show actual eval version in dropdown menu

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -54,19 +54,19 @@ const resolveEvalVersion = async (
 ) => {
   if (evalVersionProp) return evalVersionProp
 
-  if (!forceLatest && window.TSCIRCUIT_LATEST_EVAL_VERSION) {
-    return window.TSCIRCUIT_LATEST_EVAL_VERSION
-  }
-
-  const latest = await fetchLatestEvalVersion()
-  if (latest) {
-    window.TSCIRCUIT_LATEST_EVAL_VERSION = latest
-    return latest
+  if (forceLatest || !window.TSCIRCUIT_LATEST_EVAL_VERSION) {
+    const latest = await fetchLatestEvalVersion()
+    if (latest) {
+      window.TSCIRCUIT_LATEST_EVAL_VERSION = latest
+      return latest
+    }
   }
 
   if (window.TSCIRCUIT_LATEST_EVAL_VERSION) {
     return window.TSCIRCUIT_LATEST_EVAL_VERSION
   }
+
+  return "latest"
 
   return "latest"
 }

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -67,8 +67,6 @@ const resolveEvalVersion = async (
   }
 
   return "latest"
-
-  return "latest"
 }
 
 export type { RunFrameProps }

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -53,15 +53,21 @@ const resolveEvalVersion = async (
   forceLatest?: boolean,
 ) => {
   if (evalVersionProp) return evalVersionProp
-  if (forceLatest) {
-    if (window.TSCIRCUIT_LATEST_EVAL_VERSION)
-      return window.TSCIRCUIT_LATEST_EVAL_VERSION
-    const latest = await fetchLatestEvalVersion()
-    if (latest) {
-      window.TSCIRCUIT_LATEST_EVAL_VERSION = latest
-      return latest
-    }
+
+  if (!forceLatest && window.TSCIRCUIT_LATEST_EVAL_VERSION) {
+    return window.TSCIRCUIT_LATEST_EVAL_VERSION
   }
+
+  const latest = await fetchLatestEvalVersion()
+  if (latest) {
+    window.TSCIRCUIT_LATEST_EVAL_VERSION = latest
+    return latest
+  }
+
+  if (window.TSCIRCUIT_LATEST_EVAL_VERSION) {
+    return window.TSCIRCUIT_LATEST_EVAL_VERSION
+  }
+
   return "latest"
 }
 


### PR DESCRIPTION
## Summary
- resolve eval version to the numeric latest version instead of the literal string `latest`

<img width="1084" height="728" alt="image" src="https://github.com/user-attachments/assets/a87608cb-1f80-4515-b2ae-79991f4cc6c1" />


## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68844b0875e883278e774601c5e51bb4