### PR TITLE
feat: add File menu with download options to RunFrame

### DIFF
--- a/lib/components/RunFrame/FileMenu.tsx
+++ b/lib/components/RunFrame/FileMenu.tsx
@@ -1,0 +1,55 @@
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuPortal,
+  DropdownMenuSubContent,
+  DropdownMenuItem,
+} from "../ui/dropdown-menu"
+import {
+  availableExports,
+  exportAndDownload,
+} from "lib/optional-features/exporting/export-and-download"
+import { useRunFrameStore } from "../RunFrameWithApi/store"
+
+export const RunFrameFileMenu = () => {
+  const circuitJson = useRunFrameStore((s) => s.circuitJson)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <div className="rf-whitespace-nowrap rf-text-xs font-medium rf-p-2 rf-mx-1 rf-cursor-pointer rf-relative">
+          File
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="rf-text-xs">
+            Download
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              {availableExports.map((exp, i) => (
+                <DropdownMenuItem
+                  key={i}
+                  onSelect={() => {
+                    if (!circuitJson) return
+                    exportAndDownload({
+                      exportName: exp.name,
+                      circuitJson,
+                      projectName: "circuit",
+                    })
+                  }}
+                >
+                  <span className="rf-text-xs">{exp.name}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -32,6 +32,7 @@ import { useRunnerStore } from "./runner-store/use-runner-store"
 import { useMutex } from "./useMutex"
 import type { ManualEditEvent } from "@tscircuit/props"
 import { registryKy } from "../../utils/get-registry-ky"
+import { RunFrameFileMenu } from "./FileMenu"
 
 const fetchLatestEvalVersion = async () => {
   try {
@@ -158,6 +159,7 @@ export const RunFrame = (props: RunFrameProps) => {
   const [activeTab, setActiveTab] = useState<TabId>(
     props.defaultActiveTab ?? props.defaultTab ?? "pcb",
   )
+  const showFileMenu = props.showFileMenu ?? true
   useEffect(() => {
     if (props.debug) Debug.enable("run-frame*")
   }, [props.debug])
@@ -532,6 +534,7 @@ export const RunFrame = (props: RunFrameProps) => {
               )}
             </div>
           )}
+          {showFileMenu && <RunFrameFileMenu />}
           {props.leftHeaderContent}
         </>
       }

--- a/lib/components/RunFrame/RunFrameProps.tsx
+++ b/lib/components/RunFrame/RunFrameProps.tsx
@@ -41,6 +41,11 @@ export interface RunFrameProps {
   leftHeaderContent?: React.ReactNode
 
   /**
+   * Whether to show the default file menu with download options
+   */
+  showFileMenu?: boolean
+
+  /**
    * Called when the circuit JSON changes
    */
   onCircuitJsonChange?: (circuitJson: any) => void

--- a/lib/components/RunFrameForCli/RunFrameForCli.tsx
+++ b/lib/components/RunFrameForCli/RunFrameForCli.tsx
@@ -19,6 +19,7 @@ export const RunFrameForCli = (props: {
       showToggleFullScreen={false}
       workerBlobUrl={props.workerBlobUrl}
       showFilesSwitch
+      showFileMenu={false}
       leftHeaderContent={
         <div className="rf-flex rf-items-center rf-justify-between">
           <RunframeCliLeftHeader

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -36,6 +36,7 @@ export interface RunFrameWithApiProps {
   showFilesSwitch?: boolean
   workerBlobUrl?: string
   evalWebWorkerBlobUrl?: string
+  showFileMenu?: boolean
 }
 
 export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
@@ -140,6 +141,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
           )}
         </div>
       }
+      showFileMenu={props.showFileMenu}
       defaultToFullScreen={props.defaultToFullScreen}
       showToggleFullScreen={props.showToggleFullScreen}
       onInitialRender={() => {


### PR DESCRIPTION
## Summary
- add File menu with downloadable export options to RunFrame
- expose `showFileMenu` flag and wire through RunFrameWithApi and CLI

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689b3c4164bc8327823ff1c14a99c792