### PR TITLE
feat: add file loading state

### DIFF
--- a/examples/example23-loading-state.fixture.tsx
+++ b/examples/example23-loading-state.fixture.tsx
@@ -8,11 +8,11 @@ export default () => {
   useEffect(() => {
     const timer = setTimeout(() => {
       setFsMap({
-        "main.tsx": `
-import Resistor from "schematic-symbols/Resistor"
-
+        "index.tsx": `
 export default () => (
-  <Resistor resistance="1k" />
+  <board width="10mm" height="10mm">
+    <resistor name="R1" resistance="1k" footprint="0402" />
+  </board>
 )
         `.trim(),
       })
@@ -22,6 +22,6 @@ export default () => (
   }, [])
 
   return (
-    <RunFrame fsMap={fsMap} entrypoint="main.tsx" isLoadingFiles={isLoading} />
+    <RunFrame fsMap={fsMap} entrypoint="index.tsx" isLoadingFiles={isLoading} />
   )
 }

--- a/examples/example23-loading-state.fixture.tsx
+++ b/examples/example23-loading-state.fixture.tsx
@@ -9,12 +9,14 @@ export default () => {
     const timer = setTimeout(() => {
       setFsMap({
         "index.tsx": `
-export default () => (
-  <board width="10mm" height="10mm">
-    <resistor name="R1" resistance="1k" footprint="0402" />
-  </board>
-)
-        `.trim(),
+        // edit me
+        circuit.add(
+        <board width="10mm" height="10mm">
+          <resistor name="R1" resistance="1k" footprint="0402" />
+          <capacitor name="C1" capacitance="1uF" footprint="0603" pcbX={4} />
+          <trace from=".R1 .pin1" to=".C1 .pin1" />
+        </board>
+        )`.trim(),
       })
       setIsLoading(false)
     }, 2000)

--- a/examples/example23-loading-state.fixture.tsx
+++ b/examples/example23-loading-state.fixture.tsx
@@ -1,0 +1,27 @@
+import { RunFrame } from "lib/components/RunFrame/RunFrame"
+import React, { useEffect, useState } from "react"
+
+export default () => {
+  const [fsMap, setFsMap] = useState<Record<string, string>>({})
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFsMap({
+        "main.tsx": `
+import Resistor from "schematic-symbols/Resistor"
+
+export default () => (
+  <Resistor resistance="1k" />
+)
+        `.trim(),
+      })
+      setIsLoading(false)
+    }, 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <RunFrame fsMap={fsMap} entrypoint="main.tsx" isLoadingFiles={isLoading} />
+  )
+}

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -174,6 +174,7 @@ export const RunFrame = (props: RunFrameProps) => {
   const lastEntrypointRef = useRef<string | null>(null)
 
   useEffect(() => {
+    if (props.isLoadingFiles) return
     // Convert fsMap to object for consistent handling
     const fsMapObj =
       fsMap instanceof Map ? Object.fromEntries(fsMap.entries()) : fsMap
@@ -390,6 +391,7 @@ export const RunFrame = (props: RunFrameProps) => {
     runCountTrigger,
     props.evalVersion,
     props.mainComponentPath,
+    props.isLoadingFiles,
   ])
 
   // Updated to debounce edit events so only the last event is emitted after dragging ends
@@ -463,6 +465,15 @@ export const RunFrame = (props: RunFrameProps) => {
           alert(`Failed to report autorouting bug: ${error.message}`)
         }
       })
+  }
+
+  if (props.isLoadingFiles) {
+    return (
+      <div className="rf-flex rf-items-center rf-justify-center rf-w-full rf-h-full">
+        <Loader2 className="rf-w-8 rf-h-8 rf-animate-spin" />
+        <span className="rf-ml-2 rf-text-sm">Loading files...</span>
+      </div>
+    )
   }
 
   return (

--- a/lib/components/RunFrame/RunFrameProps.tsx
+++ b/lib/components/RunFrame/RunFrameProps.tsx
@@ -8,6 +8,12 @@ export interface RunFrameProps {
   fsMap: Map<string, string> | Record<string, string>
 
   /**
+   * When true, indicates the file map is still loading and a loading state
+   * should be displayed instead of attempting to execute any code.
+   */
+  isLoadingFiles?: boolean
+
+  /**
    * The entry point file that will be executed first. If not provided,
    * @tscircuit/eval will infer the entrypoint
    */

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -57,9 +57,11 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
   const circuitJson = useRunFrameStore((s) => s.circuitJson)
 
   const [componentPath, setComponentPath] = useState<string>("")
+  const [isLoadingFiles, setIsLoadingFiles] = useState(true)
 
   useEffect(() => {
-    loadInitialFiles()
+    setIsLoadingFiles(true)
+    loadInitialFiles().finally(() => setIsLoadingFiles(false))
   }, [])
 
   useEffect(() => {
@@ -120,6 +122,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
   return (
     <RunFrame
       fsMap={fsMap}
+      isLoadingFiles={isLoadingFiles}
       evalVersion={props.evalVersion}
       forceLatestEvalVersion={props.forceLatestEvalVersion}
       evalWebWorkerBlobUrl={props.evalWebWorkerBlobUrl ?? props.workerBlobUrl}


### PR DESCRIPTION
## Summary
- add optional `isLoadingFiles` prop to RunFrame
- show a loading spinner when files are being fetched
- track file loading state in RunFrameWithApi and pass to RunFrame

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68a40ba571b083318d3b7f498ccd3611