### PR TITLE
feat: proxy worker fetch through parent

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -1,4 +1,4 @@
-import { createCircuitWebWorker } from "@tscircuit/eval/worker"
+import { createCircuitWebWorker } from "../../utils/createCircuitWebWorker"
 import Debug from "debug"
 import { Loader2, Play, Square } from "lucide-react"
 import { useEffect, useReducer, useRef, useState } from "react"

--- a/lib/utils/createCircuitWebWorker.ts
+++ b/lib/utils/createCircuitWebWorker.ts
@@ -1,0 +1,76 @@
+import { createCircuitWebWorker as baseCreateCircuitWebWorker } from "@tscircuit/eval/worker"
+import type {
+  WebWorkerConfiguration,
+  CircuitWebWorker,
+} from "@tscircuit/eval/worker"
+
+/**
+ * Creates a CircuitWebWorker and sets up a fetch proxy so that any fetch calls
+ * inside the worker are forwarded to the parent thread.
+ */
+export const createCircuitWebWorker = async (
+  configuration: Partial<WebWorkerConfiguration>,
+): Promise<CircuitWebWorker> => {
+  const OriginalWorker = globalThis.Worker
+  let capturedWorker: Worker | null = null
+
+  class CapturingWorker extends OriginalWorker {
+    constructor(stringUrl: string | URL, options?: WorkerOptions) {
+      super(stringUrl, options)
+      capturedWorker = this
+    }
+  }
+  // Temporarily override global Worker constructor to capture the instance
+  ;(globalThis as any).Worker = CapturingWorker
+
+  try {
+    const worker = await baseCreateCircuitWebWorker(configuration)
+
+    if (capturedWorker) {
+      setupFetchProxy(capturedWorker)
+      // Expose raw worker for testing or advanced usage
+      ;(worker as any).__rawWorker = capturedWorker
+    } else {
+      console.warn("Failed to capture worker instance for fetch proxy")
+    }
+
+    return worker
+  } finally {
+    // Restore original Worker constructor
+    ;(globalThis as any).Worker = OriginalWorker
+  }
+}
+
+function setupFetchProxy(worker: Worker) {
+  worker.addEventListener("message", async (event: MessageEvent) => {
+    const data = event.data as any
+    if (!data || data.type !== "worker-fetch") return
+    const { requestId, url, init } = data
+    try {
+      const response = await fetch(url, init)
+      const body = await response.arrayBuffer()
+      worker.postMessage(
+        {
+          type: "worker-fetch-result",
+          requestId,
+          ok: true,
+          status: response.status,
+          headers: [...response.headers.entries()],
+          body,
+        },
+        [body],
+      )
+    } catch (err: any) {
+      worker.postMessage({
+        type: "worker-fetch-result",
+        requestId,
+        ok: false,
+        error: { name: err.name, message: err.message },
+      })
+    }
+  })
+
+  worker.postMessage({ type: "override-global-fetch" })
+}
+
+export type { CircuitWebWorker, WebWorkerConfiguration }

--- a/tests/circuitwebworker1.test.tsx
+++ b/tests/circuitwebworker1.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test"
-import { createCircuitWebWorker } from "@tscircuit/eval"
+import { createCircuitWebWorker } from "../lib/utils/createCircuitWebWorker"
 import evalWebWorkerBlobUrl from "@tscircuit/eval/blob-url"
 import type { PcbComponent } from "circuit-json"
 

--- a/tests/circuitwebworker2.test.tsx
+++ b/tests/circuitwebworker2.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test"
-import { createCircuitWebWorker } from "@tscircuit/eval"
+import { createCircuitWebWorker } from "../lib/utils/createCircuitWebWorker"
 import evalWebWorkerBlobUrl from "@tscircuit/eval/blob-url"
 import type { PcbComponent } from "circuit-json"
 

--- a/tests/worker-fetch-proxy.test.ts
+++ b/tests/worker-fetch-proxy.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "bun:test"
+import { createCircuitWebWorker } from "../lib/utils/createCircuitWebWorker"
+import evalWebWorkerBlobUrl from "@tscircuit/eval/blob-url"
+
+// Verify that worker-fetch messages are handled and forwarded to real fetch
+// by the parent thread.
+test("forwards worker fetch requests", async () => {
+  const worker = await createCircuitWebWorker({
+    webWorkerUrl: evalWebWorkerBlobUrl,
+    verbose: true,
+  })
+
+  const rawWorker = (worker as any).__rawWorker as Worker
+
+  const responsePromise = new Promise<any>((resolve) => {
+    rawWorker.postMessage = (msg: any) => {
+      resolve(msg)
+    }
+  })
+
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (url: string | URL, init?: any) => {
+    return new Response("hello")
+  }
+
+  rawWorker.dispatchEvent(
+    new MessageEvent("message", {
+      data: {
+        type: "worker-fetch",
+        requestId: "1",
+        url: "http://example.com/test",
+        init: {},
+      },
+    }),
+  )
+
+  const response = await responsePromise
+  expect(response.type).toBe("worker-fetch-result")
+  expect(response.ok).toBe(true)
+  const text = new TextDecoder().decode(response.body)
+  expect(text).toBe("hello")
+
+  globalThis.fetch = originalFetch
+  await worker.kill()
+})


### PR DESCRIPTION
## Summary
- proxy worker fetch calls through parent thread
- update RunFrame to use local worker creator
- add tests for worker fetch proxy

## Testing
- `bun run format:check`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a57b224e9883279fe635165e936bfc