### PR TITLE
refactor: move import logic into dialog

### DIFF
--- a/lib/components/FileMenuLeftHeader.tsx
+++ b/lib/components/FileMenuLeftHeader.tsx
@@ -37,7 +37,6 @@ import { AiReviewDialog } from "./AiReviewDialog"
 import { hasRegistryToken } from "lib/utils/get-registry-ky"
 import { toast } from "lib/utils/toast"
 import { Toaster } from "react-hot-toast"
-import { importComponentFromJlcpcb } from "lib/optional-features/importing/import-component-from-jlcpcb"
 import { useOrderDialogCli } from "./OrderDialog/useOrderDialog"
 
 export const FileMenuLeftHeader = (props: {
@@ -321,38 +320,6 @@ export const FileMenuLeftHeader = (props: {
       <ImportComponentDialog
         isOpen={isImportDialogOpen}
         onClose={() => setIsImportDialogOpen(false)}
-        onImport={async (component) => {
-          toast.promise(
-            async () => {
-              if (component.source === "tscircuit.com") {
-                await pushEvent({
-                  event_type: "INSTALL_PACKAGE",
-                  full_package_name: `@tsci/${component.owner}.${component.name}`,
-                })
-
-                // TODO wait on event indicating the package was successfully installed
-                throw new Error("Not implemented")
-              } else if (component.source === "jlcpcb") {
-                const { filePath } = await importComponentFromJlcpcb(
-                  component.partNumber!,
-                )
-
-                return { filePath }
-              }
-            },
-            {
-              loading: `Importing component: "${component.name}"`,
-              error: (error: Error) => {
-                console.error("IMPORT ERROR", error)
-                return `Error importing component: "${component.name}": ${error.toString()}`
-              },
-              success: (data: any) =>
-                data?.filePath
-                  ? `Imported to "${data.filePath}"`
-                  : "Import Successful",
-            },
-          )
-        }}
       />
       <AiReviewDialog
         isOpen={isAiReviewDialogOpen}

--- a/lib/optional-features/importing/import-component-from-jlcpcb.ts
+++ b/lib/optional-features/importing/import-component-from-jlcpcb.ts
@@ -2,7 +2,10 @@ import { fetchEasyEDAComponent, convertRawEasyToTsx } from "easyeda/browser"
 import { API_BASE } from "lib/components/RunFrameWithApi/api-base"
 import ky from "ky"
 
-export const importComponentFromJlcpcb = async (jlcpcbPartNumber: string) => {
+export const importComponentFromJlcpcb = async (
+  jlcpcbPartNumber: string,
+  opts?: { headers?: Record<string, string> },
+) => {
   const component = await fetchEasyEDAComponent(jlcpcbPartNumber, {
     // @ts-ignore
     fetch: (url, options: any) => {
@@ -16,6 +19,7 @@ export const importComponentFromJlcpcb = async (jlcpcbPartNumber: string) => {
           "X-Sender-Referer": options?.headers?.referer ?? "",
           "X-Sender-User-Agent": options?.headers?.userAgent ?? "",
           "X-Sender-Cookie": options?.headers?.cookie ?? "",
+          ...opts?.headers,
         },
       })
     },


### PR DESCRIPTION
## Summary
- make ImportComponentDialog handle component importing and toast messaging internally
- allow passing custom headers through ImportComponentDialog to JLCPCB proxy requests
- simplify FileMenuLeftHeader usage of ImportComponentDialog

## Testing
- `bun run format:check`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68af313ff628832cb03b431722d339af