### PR TITLE
Fix: local api server redundant logic

### DIFF
--- a/examples/example04-runframe-with-api-1.fixture.tsx
+++ b/examples/example04-runframe-with-api-1.fixture.tsx
@@ -1,5 +1,9 @@
 import { RunFrameWithApi } from "lib/components/RunFrameWithApi/RunFrameWithApi"
 import { useState, useEffect } from "react"
+import {
+  isLocalApiServerAvailable,
+  getApiNotAvailableMessage,
+} from "lib/utils/api-server-utils"
 
 export default () => {
   useEffect(() => {
@@ -34,20 +38,8 @@ circuit.add(
     }, 500)
   }, [])
 
-  if (
-    typeof window !== "undefined" &&
-    (!window.location.origin.includes("vercel.app") ||
-      !window.location.origin.includes(".com"))
-  ) {
-    return (
-      <div>
-        <h1>RunFrame with API</h1>
-        <p>
-          We don't currently deploy the API to vercel, try locally! The vite
-          plugin will automatically load it.
-        </p>
-      </div>
-    )
+  if (!isLocalApiServerAvailable()) {
+    return getApiNotAvailableMessage()
   }
 
   return <RunFrameWithApi debug />

--- a/examples/example05-runframe-for-cli.fixture.tsx
+++ b/examples/example05-runframe-for-cli.fixture.tsx
@@ -4,6 +4,10 @@ import { useRunFrameStore } from "lib/components/RunFrameWithApi/store"
 import { useState, useEffect } from "react"
 import { DebugEventsTable } from "./utils/DebugEventsTable"
 import { useEventHandler } from "lib/components/RunFrameForCli/useEventHandler"
+import {
+  isLocalApiServerAvailable,
+  getApiNotAvailableMessage,
+} from "lib/utils/api-server-utils"
 
 export default () => {
   const recentEvents = useRunFrameStore((state) => state.recentEvents)
@@ -96,20 +100,8 @@ export default () => (
     }, 500)
   }, [])
 
-  if (
-    typeof window !== "undefined" &&
-    (!window.location.origin.includes("vercel.app") ||
-      !window.location.origin.includes(".com"))
-  ) {
-    return (
-      <div>
-        <h1>RunFrame with API</h1>
-        <p>
-          We don't currently deploy the API to vercel, try locally! The vite
-          plugin will automatically load it.
-        </p>
-      </div>
-    )
+  if (!isLocalApiServerAvailable()) {
+    return getApiNotAvailableMessage()
   }
 
   return (

--- a/examples/example13-runframe-with-api-manual-edits.fixture.tsx
+++ b/examples/example13-runframe-with-api-manual-edits.fixture.tsx
@@ -1,5 +1,9 @@
 import { RunFrameWithApi } from "lib/components/RunFrameWithApi/RunFrameWithApi"
 import { useState, useEffect } from "react"
+import {
+  isLocalApiServerAvailable,
+  getApiNotAvailableMessage,
+} from "lib/utils/api-server-utils"
 
 export default () => {
   useEffect(() => {
@@ -46,19 +50,8 @@ export default () => (
     }, 500)
   }, [])
 
-  if (
-    typeof window !== "undefined" &&
-    window.location.origin.includes("vercel.app")
-  ) {
-    return (
-      <div>
-        <h1>RunFrame with API</h1>
-        <p>
-          We don't currently deploy the API to vercel, try locally! The vite
-          plugin will automatically load it.
-        </p>
-      </div>
-    )
+  if (!isLocalApiServerAvailable()) {
+    return getApiNotAvailableMessage()
   }
 
   return <RunFrameWithApi debug />

--- a/examples/example14-cli-jlcpcb-order-pipeline-scenarios.fixture.tsx
+++ b/examples/example14-cli-jlcpcb-order-pipeline-scenarios.fixture.tsx
@@ -4,6 +4,10 @@ import { useEventHandler } from "lib/components/RunFrameForCli/useEventHandler"
 import { useRunFrameStore } from "lib/components/RunFrameWithApi/store"
 import { useEffect, useState } from "react"
 import { DebugEventsTable } from "./utils/DebugEventsTable"
+import {
+  isLocalApiServerAvailable,
+  getApiNotAvailableMessage,
+} from "lib/utils/api-server-utils"
 
 export default () => {
   const recentEvents = useRunFrameStore((state) => state.recentEvents)
@@ -121,19 +125,8 @@ export default () => (
     }, 500)
   }, [])
 
-  if (
-    typeof window !== "undefined" &&
-    window.location.origin.includes("vercel.app")
-  ) {
-    return (
-      <div>
-        <h1>RunFrame with API</h1>
-        <p>
-          We don't currently deploy the API to vercel, try locally! The vite
-          plugin will automatically load it.
-        </p>
-      </div>
-    )
+  if (!isLocalApiServerAvailable()) {
+    return getApiNotAvailableMessage()
   }
 
   return (

--- a/examples/example16-Errors-tab-check.fixture.tsx
+++ b/examples/example16-Errors-tab-check.fixture.tsx
@@ -1,9 +1,11 @@
 import { RunFrameWithApi } from "lib/components/RunFrameWithApi/RunFrameWithApi"
 import { useState, useEffect } from "react"
+import {
+  isLocalApiServerAvailable,
+  getApiNotAvailableMessage,
+} from "lib/utils/api-server-utils"
 
 export default () => {
-  const [showWarning, setShowWarning] = useState(false)
-
   useEffect(() => {
     setTimeout(async () => {
       await fetch("/api/files/upsert", {
@@ -42,25 +44,10 @@ export default () => (
         }),
       })
     }, 500)
-
-    if (
-      typeof window !== "undefined" &&
-      window.location.origin.includes("vercel.app")
-    ) {
-      setShowWarning(true)
-    }
   }, [])
 
-  if (showWarning) {
-    return (
-      <div>
-        <h1>RunFrame with API</h1>
-        <p>
-          We don't currently deploy the API to vercel, try locally! The vite
-          plugin will automatically load it.
-        </p>
-      </div>
-    )
+  if (!isLocalApiServerAvailable()) {
+    return getApiNotAvailableMessage()
   }
 
   return <RunFrameWithApi debug />

--- a/lib/utils/api-server-utils.tsx
+++ b/lib/utils/api-server-utils.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+
+/**
+ * Checks if the local API server should be available
+ * Returns true if running locally (not on Vercel deployment)
+ */
+export function isLocalApiServerAvailable(): boolean {
+  if (typeof window === "undefined") {
+    return false
+  }
+
+  // API server is NOT available on Vercel deployments
+  return !window.location.origin.includes("vercel.app")
+}
+
+/**
+ * Returns JSX for the "API not available" warning message
+ */
+export function getApiNotAvailableMessage() {
+  return (
+    <div>
+      <h1>RunFrame with API</h1>
+      <p>
+        We don't currently deploy the API to vercel, try locally! The vite
+        plugin will automatically load it.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
   • Created functions in `lib/utils/api-server-utils.tsx`
   • Updated all affected examples (4, 5, 13, 14, 16) to use the shared logic
   • the examples properly check for local API server availability
   • removed duplicate API server availability checks across the codebase and examples
   • show consistent messaging when the API isn't available (like on Vercel deployments)


https://github.com/user-attachments/assets/481a3167-093d-4200-ad1b-dec8c5cccd91

@imrishabh18 @seveibar  please review!