### PR TITLE
Use static placeholder for non-code files in CLI fsMap

### DIFF
--- a/tests/fsmap-static-assets.test.ts
+++ b/tests/fsmap-static-assets.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test"
+
+test("loadInitialFiles substitutes static assets", async () => {
+  ;(globalThis as any).window = {}
+
+  const fetchCalls: string[] = []
+  const originalFetch = global.fetch
+  global.fetch = async (input: any) => {
+    const url = input.toString()
+    fetchCalls.push(url)
+    if (url.endsWith("/files/list")) {
+      return new Response(
+        JSON.stringify({
+          file_list: [
+            { file_id: "1", file_path: "index.tsx" },
+            { file_id: "2", file_path: "data.json" },
+            { file_id: "3", file_path: "style.css" },
+          ],
+        }),
+        { status: 200 },
+      )
+    }
+    if (url.includes("/files/get")) {
+      const u = new URL(url, "http://localhost")
+      const file_path = u.searchParams.get("file_path")!
+      return new Response(
+        JSON.stringify({
+          file: {
+            file_id: "x",
+            file_path,
+            text_content: `${file_path} content`,
+          },
+        }),
+        { status: 200 },
+      )
+    }
+    throw new Error(`unexpected url ${url}`)
+  }
+
+  const { useRunFrameStore } = await import(
+    "lib/components/RunFrameWithApi/store"
+  )
+
+  await useRunFrameStore.getState().loadInitialFiles()
+  const fsMap = useRunFrameStore.getState().fsMap
+
+  expect(fsMap.get("index.tsx")).toBe("index.tsx content")
+  expect(fsMap.get("data.json")).toBe("data.json content")
+  expect(fsMap.get("style.css")).toBe("__STATIC_ASSET__")
+  expect(
+    fetchCalls.filter(
+      (u) => u.includes("style.css") && u.includes("/files/get"),
+    ).length,
+  ).toBe(0)
+
+  global.fetch = originalFetch
+  // @ts-ignore
+  delete globalThis.window
+})


### PR DESCRIPTION
## Summary
- load only JS/TS/JSON file contents for CLI/API fsMap and mark other files as static assets
- add test ensuring non-code files are replaced by `__STATIC_ASSET__`

## Testing
- `bunx tsc --noEmit`
- `bun test tests`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c4f0d375d0832eb751857e68aa0d2a