### PR TITLE
Fix KiCad capitalization in import dialog

### DIFF
--- a/lib/components/ImportComponentDialog/ImportComponentDialog.tsx
+++ b/lib/components/ImportComponentDialog/ImportComponentDialog.tsx
@@ -253,7 +253,7 @@ export const ImportComponentDialog = ({
               JLCPCB Parts
             </TabsTrigger>
             <TabsTrigger value="kicad" className="rf-text-xs sm:rf-text-sm">
-              Kicad
+              KiCad
             </TabsTrigger>
           </TabsList>
 
@@ -265,7 +265,7 @@ export const ImportComponentDialog = ({
                   activeTab === "tscircuit.com"
                     ? "Search components..."
                     : activeTab === "kicad"
-                      ? "Search Kicad footprints..."
+                      ? "Search KiCad footprints..."
                       : "Search JLCPCB parts (e.g. C14663)..."
                 }
                 className="rf-pl-8"


### PR DESCRIPTION
## Summary
- update the import dialog tab label to spell "KiCad" correctly
- correct the KiCad search placeholder text to use the proper capitalization

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68c9a6551cf8832ebff3817fdb59e785