### PR TITLE
Persist CLI main component selection in URL hash

### DIFF
--- a/lib/components/RunFrameForCli/RunFrameForCli.tsx
+++ b/lib/components/RunFrameForCli/RunFrameForCli.tsx
@@ -1,4 +1,5 @@
 import { useLocalStorageState } from "lib/hooks/use-local-storage-state"
+import { useCallback, useState } from "react"
 import { RunFrameWithApi } from "../RunFrameWithApi/RunFrameWithApi"
 import { FileMenuLeftHeader } from "../FileMenuLeftHeader"
 
@@ -12,6 +13,24 @@ export const RunFrameForCli = (props: {
     "load-latest-eval",
     true,
   )
+  const [initialMainComponentPath] = useState<string | undefined>(() => {
+    if (typeof window === "undefined") return undefined
+    const params = new URLSearchParams(window.location.hash.slice(1))
+    return params.get("main_component") ?? undefined
+  })
+
+  const updateMainComponentHash = useCallback((mainComponentPath: string) => {
+    if (typeof window === "undefined") return
+    const params = new URLSearchParams(window.location.hash.slice(1))
+    if (params.get("main_component") === mainComponentPath) return
+    params.set("main_component", mainComponentPath)
+    const newHash = params.toString()
+    const newUrl =
+      `${window.location.pathname}${window.location.search}` +
+      (newHash.length > 0 ? `#${newHash}` : "")
+    window.history.replaceState(null, "", newUrl)
+  }, [])
+
   return (
     <RunFrameWithApi
       debug={props.debug}
@@ -22,6 +41,8 @@ export const RunFrameForCli = (props: {
       showFilesSwitch
       showFileMenu={false}
       enableFetchProxy={props.enableFetchProxy}
+      initialMainComponentPath={initialMainComponentPath}
+      onMainComponentPathChange={updateMainComponentHash}
       leftHeaderContent={
         <div className="rf-flex rf-items-center rf-justify-between">
           <FileMenuLeftHeader

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -41,6 +41,14 @@ export interface RunFrameWithApiProps {
    * Enable fetch proxy for the web worker (useful for standalone bundles)
    */
   enableFetchProxy?: boolean
+  /**
+   * The main component path that should be selected initially when available.
+   */
+  initialMainComponentPath?: string
+  /**
+   * Callback invoked whenever the selected main component path changes.
+   */
+  onMainComponentPathChange?: (path: string) => void
 }
 
 export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
@@ -60,7 +68,9 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
   const fsMap = useRunFrameStore((s) => s.fsMap)
   const circuitJson = useRunFrameStore((s) => s.circuitJson)
 
-  const [componentPath, setComponentPath] = useState<string>("")
+  const [componentPath, setComponentPath] = useState<string>(
+    props.initialMainComponentPath ?? "",
+  )
   const [isLoadingFiles, setIsLoadingFiles] = useState(true)
 
   useEffect(() => {
@@ -75,22 +85,34 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
       return
     }
     const defaultPath = window?.TSCIRCUIT_DEFAULT_MAIN_COMPONENT_PATH
-    if (defaultPath && files.includes(defaultPath)) {
-      setComponentPath(defaultPath)
-    } else {
-      const firstMatch = files.find(
-        (file) =>
-          (file.endsWith(".tsx") ||
-            file.endsWith(".ts") ||
-            file.endsWith(".jsx") ||
-            file.endsWith(".js")) &&
-          !file.endsWith(".d.ts"),
-      )
-      if (firstMatch) {
-        setComponentPath(firstMatch)
+    const candidatePaths = [props.initialMainComponentPath, defaultPath].filter(
+      (value): value is string => Boolean(value),
+    )
+
+    for (const candidate of candidatePaths) {
+      if (files.includes(candidate)) {
+        setComponentPath(candidate)
+        return
       }
     }
-  }, [fsMap])
+
+    const firstMatch = files.find(
+      (file) =>
+        (file.endsWith(".tsx") ||
+          file.endsWith(".ts") ||
+          file.endsWith(".jsx") ||
+          file.endsWith(".js")) &&
+        !file.endsWith(".d.ts"),
+    )
+    if (firstMatch) {
+      setComponentPath(firstMatch)
+    }
+  }, [fsMap, props.initialMainComponentPath, componentPath])
+
+  useEffect(() => {
+    if (!componentPath) return
+    props.onMainComponentPathChange?.(componentPath)
+  }, [componentPath, props.onMainComponentPathChange])
   useSyncPageTitle()
 
   const {


### PR DESCRIPTION
## Summary
- read any existing `main_component` hash parameter when mounting RunFrameForCli and pass it to RunFrameWithApi
- add RunFrameWithApi hooks that prefer the provided initial main component path and report selection changes
- update the CLI frame to write the selected main component back to the URL hash via history.replaceState

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68cace13b71c832e86fc732f24c94dc4