### PR TITLE
Exclude test files as entries from file selector dropdown

### DIFF
--- a/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
+++ b/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
@@ -58,14 +58,23 @@ export const EnhancedFileSelectorCombobox = ({
     setFile(currentFile)
   }, [currentFile])
 
-  const filteredFiles = files.filter(
-    (file) =>
-      (file.endsWith(".tsx") ||
-        file.endsWith(".ts") ||
-        file.endsWith(".jsx") ||
-        file.endsWith(".js")) &&
-      !file.endsWith(".d.ts"),
-  )
+  const filteredFiles = files.filter((file) => {
+    const fileName = file.split("/").pop() ?? ""
+    const lowerCaseFileName = fileName.toLowerCase()
+    const isScriptFile =
+      file.endsWith(".tsx") ||
+      file.endsWith(".ts") ||
+      file.endsWith(".jsx") ||
+      file.endsWith(".js")
+
+    if (!isScriptFile || file.endsWith(".d.ts")) return false
+
+    if (lowerCaseFileName.startsWith("test.tsx")) {
+      return false
+    }
+
+    return true
+  })
 
   const fileTree = parseFilesToTree(filteredFiles)
   const { files: currentFiles, folders: currentFolders } =


### PR DESCRIPTION
## Summary
- prevent the enhanced file selector dropdown from listing files whose names start with test.tsx
- centralize file filtering logic so these generated test files are ignored

## Testing
- bun run format:check

------
https://chatgpt.com/codex/tasks/task_b_68cd752c05688327a0ca45061a3f651d