### PR TITLE
Ensure ImportComponentDialog2 loads shared styles

### DIFF
--- a/lib/components/ImportComponentDialog2/ImportComponentDialog2.tsx
+++ b/lib/components/ImportComponentDialog2/ImportComponentDialog2.tsx
@@ -25,6 +25,7 @@ import type {
 import { useTscircuitPackageSearch } from "./hooks/useTscircuitPackageSearch"
 import { useJlcpcbComponentSearch } from "./hooks/useJlcpcbComponentSearch"
 import { useKicadFootprintSearch } from "./hooks/useKicadFootprintSearch"
+import { useStyles } from "../../hooks/use-styles"
 
 const computeAvailableSources = ({
   onTscircuitPackageSelected,
@@ -51,6 +52,8 @@ export const ImportComponentDialog2 = ({
   onTscircuitPackageSelected,
   onJlcpcbComponentTsxLoaded,
 }: ImportComponentDialog2Props) => {
+  useStyles()
+
   const availableSources = React.useMemo(
     () =>
       computeAvailableSources({


### PR DESCRIPTION
## Summary
- import the useStyles hook into ImportComponentDialog2
- invoke useStyles so the dialog loads the shared styles when rendered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dbff99ee80832cb70ffa9e93eea6a8