### PR TITLE
Add Pinout SVG export option

### DIFF
--- a/lib/optional-features/exporting/export-and-download.ts
+++ b/lib/optional-features/exporting/export-and-download.ts
@@ -2,6 +2,7 @@ import type { CircuitJson } from "circuit-json"
 import { exportFabricationFiles } from "./formats/export-fabrication-files"
 import { openForDownload } from "./open-for-download"
 import { exportGlb } from "./formats/export-glb"
+import { exportPinoutSvg } from "./formats/export-pinout-svg"
 import { exportKicadProject } from "./formats/export-kicad-project"
 
 export const availableExports = [
@@ -9,6 +10,7 @@ export const availableExports = [
   { extension: "zip", name: "Fabrication Files" },
   { extension: "zip", name: "KiCad Project" },
   { extension: "glb", name: "GLB (Binary GLTF)" },
+  { extension: "svg", name: "Pinout SVG" },
   // { extension: "svg", name: "SVG" },
   // { extension: "dsn", name: "Specctra DSN" },
   // { extension: "kicad_mod", name: "KiCad Module" },
@@ -43,6 +45,10 @@ export const exportAndDownload = async ({
   }
   if (exportName === "GLB (Binary GLTF)") {
     await exportGlb({ circuitJson, projectName })
+    return
+  }
+  if (exportName === "Pinout SVG") {
+    exportPinoutSvg({ circuitJson, projectName })
     return
   }
   throw new Error(`Unsupported export type: "${exportName}"`)

--- a/lib/optional-features/exporting/formats/export-pinout-svg.ts
+++ b/lib/optional-features/exporting/formats/export-pinout-svg.ts
@@ -1,0 +1,18 @@
+import type { CircuitJson } from "circuit-json"
+import { convertCircuitJsonToPinoutSvg } from "circuit-to-svg"
+import { openForDownload } from "../open-for-download"
+
+export const exportPinoutSvg = ({
+  circuitJson,
+  projectName,
+}: {
+  circuitJson: CircuitJson
+  projectName: string
+}) => {
+  const svgString = convertCircuitJsonToPinoutSvg(circuitJson)
+
+  openForDownload(svgString, {
+    fileName: `${projectName}-pinout.svg`,
+    mimeType: "image/svg+xml",
+  })
+}


### PR DESCRIPTION
## Summary
- expose a Pinout SVG option in the export menu
- implement pinout SVG export using circuit-to-svg and download helper

## Testing
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68e02b9035c8832ea8ce30d7bfa90387