### PR TITLE
Don't show *ts files in RunFrame file explorer, only *.tsx and *.circuit.json #1381

### DIFF
--- a/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
+++ b/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
@@ -48,13 +48,7 @@ const defaultFileIcon = (fileName: string) => {
 }
 
 const defaultFileFilter = (filename: string) => {
-  return (
-    (filename.endsWith(".tsx") ||
-      filename.endsWith(".ts") ||
-      filename.endsWith(".jsx") ||
-      filename.endsWith(".js")) &&
-    !filename.endsWith(".d.ts")
-  )
+  return filename.endsWith(".tsx") || filename.endsWith(".circuit.json")
 }
 
 const defaultDisplayName = (filename: string) => {


### PR DESCRIPTION
fix #1381 
/claim #1381
<img width="1116" height="557" alt="image" src="https://github.com/user-attachments/assets/d829f622-ad34-4b78-b5a0-e9c73dc2e5ee" />
