### PR TITLE
Don't show *ts files in RunFrame file explorer, only *.tsx and *.circuit.json

### DIFF
--- a/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
+++ b/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
@@ -51,7 +51,7 @@ const defaultFileFilter = (filename: string) => {
   return (
     filename.endsWith(".tsx") ||
     filename.endsWith(".jsx") ||
-    filename.endsWith(".ciruit.json")
+    filename.endsWith(".circuit.json")
   )
 }
 


### PR DESCRIPTION
/claim https://github.com/tscircuit/runframe/issues/1381