### PR TITLE
Remove deleted files from the file dropdown

### DIFF
--- a/examples/example32-file-deletion-test.fixture.tsx
+++ b/examples/example32-file-deletion-test.fixture.tsx
@@ -1,0 +1,79 @@
+import { RunFrameWithApi } from "lib/components/RunFrameWithApi/RunFrameWithApi"
+import { useState, useEffect } from "react"
+import { isFileApiAccessible } from "./utils/isFileApiAccessible.ts"
+
+export default () => {
+  const [deletedFile, setDeletedFile] = useState<string | null>(null)
+
+  useEffect(() => {
+    // Create test files
+    setTimeout(async () => {
+      await fetch("/api/files/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          file_path: "test1.tsx",
+          text_content: `export default () => (
+  <board width="10mm" height="10mm">
+    <resistor name="R1" resistance="1k" footprint="0402" />
+  </board>
+)`,
+        }),
+      })
+
+      await fetch("/api/files/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          file_path: "test2.tsx",
+          text_content: `export default () => (
+  <board width="20mm" height="20mm">
+    <capacitor name="C1" capacitance="10uF" footprint="0603" />
+  </board>
+)`,
+        }),
+      })
+    }, 500)
+  }, [])
+
+  const deleteFile = async (filePath: string) => {
+    await fetch("/api/events/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event_type: "FILE_DELETED",
+        file_path: filePath,
+      }),
+    })
+    setDeletedFile(filePath)
+  }
+
+  if (!isFileApiAccessible()) {
+    return <div>API not accessible</div>
+  }
+
+  return (
+    <div>
+      <div style={{ padding: "10px", background: "#f0f0f0" }}>
+        <button
+          onClick={() => deleteFile("test1.tsx")}
+          style={{ marginRight: "10px" }}
+        >
+          Delete test1.tsx
+        </button>
+        <button
+          onClick={() => deleteFile("test2.tsx")}
+          style={{ marginRight: "10px" }}
+        >
+          Delete test2.tsx
+        </button>
+        {deletedFile && (
+          <span style={{ marginLeft: "10px", color: "red" }}>
+            ✓ Deleted: {deletedFile}
+          </span>
+        )}
+      </div>
+      <RunFrameWithApi debug showFilesSwitch />
+    </div>
+  )
+}

--- a/lib/components/RunFrameWithApi/store.ts
+++ b/lib/components/RunFrameWithApi/store.ts
@@ -148,6 +148,8 @@ export const useRunFrameStore = create<RunFrameState>()(
                   } else {
                     updates.set(file.file_path, "__STATIC_ASSET__")
                   }
+                } else if (event.event_type === "FILE_DELETED") {
+                  updates.delete(event.file_path)
                 }
               }
 

--- a/lib/components/RunFrameWithApi/types.ts
+++ b/lib/components/RunFrameWithApi/types.ts
@@ -19,6 +19,13 @@ export interface FileUpdatedEvent {
   created_at: string
 }
 
+export interface FileDeletedEvent {
+  event_id: string
+  event_type: "FILE_DELETED"
+  file_path: FilePath
+  created_at: string
+}
+
 export interface RequestToSaveSnippetEvent {
   event_id: string
   event_type: "REQUEST_TO_SAVE_SNIPPET"
@@ -68,6 +75,7 @@ export interface RequestToExportSnippetEvent {
 
 export type RunFrameEvent =
   | FileUpdatedEvent
+  | FileDeletedEvent
   | RequestToSaveSnippetEvent
   | FailedToSaveSnippetEvent
   | SnippetSavedEvent


### PR DESCRIPTION
## PR  description

In this implementation, I've added the feature to remove deleted files from the file dropdown. Here are the changes done:

- Added a new `FileDeletedEvent` interface to represent file deletion events
- Added `FileDeletedEvent` to the `RunFrameEvent` union type
- Updated the polling logic to handle `FILE_DELETED` events
- When a `FILE_DELETED` event is received, the file is removed from the `fsMap`
- Added an example to demonstrate the feature

## Demo 

https://github.com/user-attachments/assets/b7df9234-bc98-430f-9f3f-8cc3ecef3a18





fixes #1460 
/claim #1460 