### PR TITLE
Feat: Auto-render on component move

### DIFF
--- a/examples/example13-runframe-with-api-manual-edits.fixture.tsx
+++ b/examples/example13-runframe-with-api-manual-edits.fixture.tsx
@@ -67,5 +67,5 @@ export default () => (
     )
   }
 
-  return <RunFrameWithApi debug />
+  return <RunFrameWithApi debug autoRenderOnEdit={true} showRunButton={false} />
 }

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -228,6 +228,7 @@ export const RunFrame = (props: RunFrameProps) => {
     lastEntrypointRef.current = props.entrypoint ?? null
     lastRunCountTriggerRef.current = runCountTrigger
     setIsRunning(true)
+    setShowRerunMessage(false)
 
     const runWorker = async () => {
       debug("running render worker")
@@ -432,6 +433,8 @@ export const RunFrame = (props: RunFrameProps) => {
     currentDebugOption,
   ])
 
+  const [showRerunMessage, setShowRerunMessage] = useState(false)
+
   // Updated to debounce edit events so only the last event is emitted after dragging ends
   const lastEditEventRef = useRef<any>(null)
   const dragTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -458,6 +461,12 @@ export const RunFrame = (props: RunFrameProps) => {
         props.onEditEvent?.(eventToSend)
         lastEditEventRef.current = null
         dragTimeout.current = null
+
+        if (props.autoRenderOnEdit) {
+          incRunCountTrigger(1)
+        } else {
+          setShowRerunMessage(true)
+        }
       }, 100)
     }
   }
@@ -541,6 +550,19 @@ export const RunFrame = (props: RunFrameProps) => {
                   <Play className="rf-w-3 rf-h-3" />
                 )}
               </button>
+              {showRerunMessage && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    incRunCountTrigger(1)
+                    setShowRerunMessage(false)
+                  }}
+                  className="rf-flex rf-items-center rf-gap-2 rf-px-4 rf-py-2 rf-bg-blue-600 hover:rf-bg-blue-700 rf-text-white rf-rounded-md disabled:rf-opacity-50 transition-colors duration-200 rf-ml-2"
+                  disabled={isRunning || !dependenciesLoaded}
+                >
+                  Rerun to reroute
+                </button>
+              )}
               {isRunning && (
                 <div className="rf-flex rf-items-center rf-ml-1">
                   <Button

--- a/lib/components/RunFrame/RunFrameProps.tsx
+++ b/lib/components/RunFrame/RunFrameProps.tsx
@@ -133,4 +133,8 @@ export interface RunFrameProps {
    * Enable fetch proxy for the web worker (useful for standalone bundles)
    */
   enableFetchProxy?: boolean
+  /**
+   * Whether to auto-render on edit
+   */
+  autoRenderOnEdit?: boolean
 }

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -53,6 +53,8 @@ export interface RunFrameWithApiProps {
    * Callback invoked whenever the selected main component path changes.
    */
   onMainComponentPathChange?: (path: string) => void
+  autoRenderOnEdit?: boolean
+  showRunButton?: boolean
 }
 
 export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
@@ -188,6 +190,8 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
       }
       defaultToFullScreen={props.defaultToFullScreen}
       showToggleFullScreen={props.showToggleFullScreen}
+      autoRenderOnEdit={props.autoRenderOnEdit ?? false}
+      showRunButton={props.showRunButton ?? true}
       onInitialRender={() => {
         debug("onInitialRender / markRenderStarted")
         markRenderStarted()


### PR DESCRIPTION
/claim #387 

This PR implements auto-rendering of traces when a component is moved in a manual-edit scenario.
Demo Video: https://github.com/user-attachments/files/22990672/Feat_.Auto-render.on.component.move.by.Excellencedev.Pull.Request.1509.tscircuit_runframe.-.Brave.2025-10-19.15-12-52.zip

**Changes:**

- Added a new prop `autoRenderOnEdit` to `RunFrame` and `RunFrameWithApi`.
- If `autoRenderOnEdit` is `true`, the circuit will be re-rendered after an edit event.
- If `autoRenderOnEdit` is `false`, a "Rerun to reroute" button will be displayed.
- Updated the fixture `example13-runframe-with-api-manual-edits.fixture.tsx` to enable the auto-render feature and hide the run button.

**Issue:** Closes #387
