### PR TITLE
feat: enhance RunFrameProps with projectBaseUrl and platformConfig

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -140,8 +140,12 @@ export const RunFrame = (props: RunFrameProps) => {
             evalVersion,
             webWorkerBlobUrl: props.evalWebWorkerBlobUrl,
             projectConfig: {
-              projectBaseUrl: `${API_BASE}/files/static`,
+              projectBaseUrl:
+                props.projectBaseUrl || `${API_BASE}/files/static`,
             },
+            ...(props.platformConfig && {
+              platformConfig: props.platformConfig,
+            }),
             verbose: true,
             ...(props.enableFetchProxy && {
               enableFetchProxy: props.enableFetchProxy,
@@ -255,8 +259,11 @@ export const RunFrame = (props: RunFrameProps) => {
           webWorkerBlobUrl: props.evalWebWorkerBlobUrl,
           verbose: true,
           projectConfig: {
-            projectBaseUrl: `${API_BASE}/files/static`,
+            projectBaseUrl: props.projectBaseUrl || `${API_BASE}/files/static`,
           },
+          ...(props.platformConfig && {
+            platformConfig: props.platformConfig,
+          }),
           ...(props.enableFetchProxy && {
             enableFetchProxy: props.enableFetchProxy,
           }),

--- a/lib/components/RunFrame/RunFrameProps.tsx
+++ b/lib/components/RunFrame/RunFrameProps.tsx
@@ -1,4 +1,4 @@
-import type { ManualEditEvent } from "@tscircuit/props"
+import type { ManualEditEvent, PlatformConfig } from "@tscircuit/props"
 import type { TabId } from "lib/components/CircuitJsonPreview/PreviewContentProps"
 
 export interface RunFrameProps {
@@ -123,6 +123,16 @@ export interface RunFrameProps {
    * reporting autorouting bugs
    */
   projectUrl?: string
+
+  /**
+   * Base URL for the project, used in webworker platform config
+   */
+  projectBaseUrl?: string
+
+  /**
+   * Platform config for the eval webworker
+   */
+  platformConfig?: PlatformConfig
 
   onReportAutoroutingLog?: (
     name: string,


### PR DESCRIPTION
- Added optional projectBaseUrl to support custom project URLs.
- Introduced platformConfig for the eval webworker to allow platform-specific configurations.
- Updated RunFrame component to utilize new props for projectBaseUrl and platformConfig.