### PR TITLE
feat: cycle through files in the same directory without opening file selector

### DIFF
--- a/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
+++ b/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
@@ -238,7 +238,10 @@ export const EnhancedFileSelectorCombobox = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        (e.key === "ArrowLeft" || e.key === "ArrowRight")
+      ) {
         e.preventDefault()
 
         if (!currentFile || currentFiles.length === 0) return


### PR DESCRIPTION
- Cmd/Ctrl+left arrow switches to the previous file
- Cmd/Ctrl+right arrow switches to the next file