### PR TITLE
Fix: Auto-scale PCB on file change by keying PCBViewer with circuitJsonKey

### DIFF
--- a/lib/components/PcbViewerWithContainerHeight.tsx
+++ b/lib/components/PcbViewerWithContainerHeight.tsx
@@ -1,5 +1,11 @@
-import { useRef, useState, useLayoutEffect, type ComponentProps } from "react"
-import { PCBViewer } from "@tscircuit/pcb-viewer"
+import {
+  useRef,
+  useState,
+  useLayoutEffect,
+  useMemo,
+  type ComponentProps,
+} from "react"
+import { PCBViewer, calculateCircuitJsonKey } from "@tscircuit/pcb-viewer"
 
 export const PcbViewerWithContainerHeight = ({
   containerClassName,
@@ -9,6 +15,11 @@ export const PcbViewerWithContainerHeight = ({
 } & ComponentProps<typeof PCBViewer>) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [computedHeight, setComputedHeight] = useState(620)
+
+  const circuitJsonKey = useMemo(
+    () => calculateCircuitJsonKey(props.circuitJson),
+    [props.circuitJson],
+  )
 
   useLayoutEffect(() => {
     const updateHeight = () => {
@@ -44,7 +55,7 @@ export const PcbViewerWithContainerHeight = ({
       ref={containerRef}
       className={containerClassName || "rf-w-full rf-h-full"}
     >
-      <PCBViewer {...props} height={computedHeight} />
+      <PCBViewer key={circuitJsonKey} {...props} height={computedHeight} />
     </div>
   )
 }


### PR DESCRIPTION
1. `PCBViewer`’s `useEffect` calls `resetTransform()` on mount or when `circuitJson` changes.  
2. Added a `key` prop using `calculateCircuitJsonKey(circuitJson)` in `PcbViewerWithContainerHeight.tsx`.  
3. When a new board loads, `circuitJson` (and key) changes, causing React to remount `PCBViewer`.  
4. The remount triggers `resetTransform()`, auto-scaling the view to the new board.

