### PR TITLE
fix: remove runframe copy alert and make a react-hot-toast popup

### DIFF
--- a/lib/components/ErrorTabContent/ErrorTabContent.tsx
+++ b/lib/components/ErrorTabContent/ErrorTabContent.tsx
@@ -6,6 +6,7 @@ import { encodeFsMapToUrlHash } from "lib/utils"
 import { AutoroutingLogOptions } from "./AutoroutingLogOptions"
 import { useState, useMemo, useEffect } from "react"
 import type { CircuitJsonError } from "circuit-json"
+import { toast } from "lib/utils/toast"
 
 declare global {
   interface Window {
@@ -299,7 +300,7 @@ export const ErrorTabContent = ({
               if (softwareUsedString) errorText += `\n${softwareUsedString}`
               if (currentError.stack) errorText += `\n${currentError.stack}`
               navigator.clipboard.writeText(errorText)
-              alert("Error copied to clipboard!")
+              toast.success("Error copied to clipboard!")
             }}
           >
             <ClipboardIcon className="rf-w-4 rf-h-4" />


### PR DESCRIPTION
<img width="1102" height="486" alt="image" src="https://github.com/user-attachments/assets/aa9faae1-0868-43c7-a24f-a093b32a9afb" />

https://runframe-g3o88ftwl-tscircuit.vercel.app/?fixtureId=%7B%22path%22%3A%22examples%2Fexample10-error-cases.fixture.tsx%22%7D