### PR TITLE
Fix pushEvent API base

### DIFF
--- a/lib/components/RunFrameWithApi/store.ts
+++ b/lib/components/RunFrameWithApi/store.ts
@@ -178,16 +178,13 @@ export const useRunFrameStore = create<RunFrameState>()(
       pushEvent: async (
         event: Omit<RunFrameEvent, "event_id" | "created_at">,
       ) => {
-        await fetch(
-          `${window.TSCIRCUIT_FILESERVER_API_BASE_URL ?? ""}/api/events/create`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(event),
+        await fetch(`${API_BASE}/events/create`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
           },
-        )
+          body: JSON.stringify(event),
+        })
       },
 
       applyEditEventsAndUpdateManualEditsJson: async (


### PR DESCRIPTION
## Summary
- ensure RunFrame pushEvent uses the shared API_BASE so event creation requests hit the correct path

## Testing
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69191bf480a0832e8d19feaad744fd9d)