### PR TITLE
Add LightBurn preview to export dialog

### DIFF
--- a/lib/components/FileMenuLeftHeader.tsx
+++ b/lib/components/FileMenuLeftHeader.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
+import type { CircuitJson } from "circuit-json"
 import { useRunFrameStore } from "./RunFrameWithApi/store"
 import type {
   FailedToSaveSnippetEvent,
@@ -76,7 +77,7 @@ export const FileMenuLeftHeader = (props: {
   const [isExporting, setisExporting] = useState(false)
   const [isLbrnDialogOpen, setIsLbrnDialogOpen] = useState(false)
   const [pendingLbrnExport, setPendingLbrnExport] = useState<{
-    circuitJson: any
+    circuitJson: CircuitJson
     projectName: string
   } | null>(null)
   const orderDialog = useOrderDialogCli()
@@ -393,6 +394,7 @@ export const FileMenuLeftHeader = (props: {
         open={isLbrnDialogOpen}
         onOpenChange={setIsLbrnDialogOpen}
         onExport={handleLbrnExport}
+        circuitJson={pendingLbrnExport?.circuitJson}
       />
       <ImportComponentDialogForCli
         isOpen={isImportDialogOpen}

--- a/lib/components/LbrnExportOptionsDialog.tsx
+++ b/lib/components/LbrnExportOptionsDialog.tsx
@@ -1,4 +1,7 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import type { CircuitJson } from "circuit-json"
+import { generateLightBurnSvg } from "lbrnts"
+import { convertCircuitJsonToLbrn } from "circuit-json-to-lbrn"
 import {
   Dialog,
   DialogContent,
@@ -18,14 +21,46 @@ interface LbrnExportOptionsDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onExport: (options: LbrnExportOptions) => void
+  circuitJson?: CircuitJson | null
 }
 
 export function LbrnExportOptionsDialog({
   open,
   onOpenChange,
   onExport,
+  circuitJson,
 }: LbrnExportOptionsDialogProps) {
   const [includeSilkscreen, setIncludeSilkscreen] = useState(false)
+  const [previewSvg, setPreviewSvg] = useState<string | null>(null)
+  const [isGeneratingPreview, setIsGeneratingPreview] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !circuitJson) {
+      setPreviewSvg(null)
+      setPreviewError(null)
+      return
+    }
+
+    setIsGeneratingPreview(true)
+    try {
+      const project = convertCircuitJsonToLbrn(circuitJson, {
+        includeSilkscreen,
+      })
+      const svg = generateLightBurnSvg(project)
+      setPreviewSvg(svg)
+      setPreviewError(null)
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Unknown error generating preview"
+      setPreviewSvg(null)
+      setPreviewError(errorMessage)
+    } finally {
+      setIsGeneratingPreview(false)
+    }
+  }, [circuitJson, includeSilkscreen, open])
 
   const handleExport = () => {
     onExport({ includeSilkscreen })
@@ -61,6 +96,34 @@ export function LbrnExportOptionsDialog({
             >
               Include silkscreen layer
             </label>
+          </div>
+
+          <div className="rf-space-y-2">
+            <p className="rf-text-xs rf-font-semibold">Preview</p>
+            <div className="rf-rounded-md rf-border rf-bg-muted/50 rf-p-3 rf-text-xs">
+              {!circuitJson && (
+                <p className="rf-text-muted-foreground">
+                  Load a circuit to generate a preview.
+                </p>
+              )}
+
+              {circuitJson && isGeneratingPreview && (
+                <p className="rf-text-muted-foreground">
+                  Generating preview...
+                </p>
+              )}
+
+              {previewError && (
+                <p className="rf-text-destructive">{previewError}</p>
+              )}
+
+              {previewSvg && !isGeneratingPreview && !previewError && (
+                <div
+                  className="rf-flex rf-items-center rf-justify-center rf-overflow-hidden rf-rounded rf-bg-white rf-p-2"
+                  dangerouslySetInnerHTML={{ __html: previewSvg }}
+                />
+              )}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add LightBurn SVG preview generation in the export options dialog
- plumb circuit data into the dialog for preview rendering and error handling

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692151dce040832e9871ca23878fe00c)