### PR TITLE
Fix the hover for items in file selector

### DIFF
--- a/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
+++ b/lib/components/RunFrameWithApi/EnhancedFileSelectorCombobox/EnhancedFileSelectorCombobox.tsx
@@ -429,7 +429,7 @@ export const EnhancedFileSelectorCombobox = ({
                         recentFiles.map((path, index) => (
                           <CommandItem
                             key={path}
-                            value={path}
+                            value={`recent:${path}`}
                             onSelect={() => selectFile(path, index, true)}
                             className={cn(
                               path === currentFile && "rf-font-medium",
@@ -464,7 +464,7 @@ export const EnhancedFileSelectorCombobox = ({
                         .map((path, index) => (
                           <CommandItem
                             key={path}
-                            value={path}
+                            value={`favorite:${path}`}
                             onSelect={() => selectFile(path, index, true)}
                             className={cn(
                               path === currentFile && "rf-font-medium",
@@ -510,7 +510,7 @@ export const EnhancedFileSelectorCombobox = ({
                       {currentFiles.map((fileNode, index) => (
                         <CommandItem
                           key={fileNode.path}
-                          value={fileNode.path}
+                          value={`current:${fileNode.path}`}
                           onSelect={() => selectFile(fileNode.path, index)}
                           className={cn(
                             fileNode.path === currentFile && "rf-font-medium",
@@ -616,7 +616,7 @@ export const EnhancedFileSelectorCombobox = ({
                             (file, index) => (
                               <CommandItem
                                 key={file.path}
-                                value={file.path}
+                                value={`search-current:${file.path}`}
                                 onSelect={() => {
                                   setFile(file.path)
                                   setOpen(false)
@@ -687,7 +687,7 @@ export const EnhancedFileSelectorCombobox = ({
                           {searchResults.globalResults.map((file) => (
                             <CommandItem
                               key={file.path}
-                              value={file.path}
+                              value={`search-global:${file.path}`}
                               onSelect={() => {
                                 setFile(file.path)
                                 setOpen(false)


### PR DESCRIPTION
When the same file (e.g., app.tsx) appears in both the "Recent" section and "Favorites" section, both CommandItem elements use `value={path}]` (the file path). The cmdk library uses this value attribute to track hover/selection state, so hovering over one triggers the hover effect on all items with the same value.

The fix: Make the `value` prop unique for each section by prefixing it with the section name.



**Before**

https://github.com/user-attachments/assets/600b1638-b645-41e6-b776-1b22191ffae7

**After**

https://github.com/user-attachments/assets/cc1a4a3a-2fec-4db1-823e-c8fe7013fde6

