### PR TITLE
fix: 3D viewer not rerendering properly in full screen mode

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -615,6 +615,7 @@ export const CircuitJsonPreview = ({
                 <ErrorBoundary FallbackComponent={ErrorFallback}>
                   {circuitJson ? (
                     <CadViewer
+                      key={`cad-${isFullScreen}`}
                       ref={setCadViewerRef}
                       circuitJson={circuitJson as any}
                       autoRotateDisabled={autoRotate3dViewerDisabled}


### PR DESCRIPTION
This pull request introduces a minor update to the `CircuitJsonPreview` component to address an issue with the `CadViewer` component not re-rendering correctly when toggling fullscreen mode.

- Added a `key` prop to the `CadViewer` component, using the value of `isFullScreen`, to ensure the component re-renders properly when fullscreen mode is toggled.
- This forces React to remount the component when full screen is toggled, ensuring proper rerendering and resizing

Also tested using `bun link` to ensure the changes work in linked package

## Before
<img width="1920" height="1080" alt="Screenshot_20251127_102239" src="https://github.com/user-attachments/assets/dab83e38-66e3-4b1a-b52d-976b9f841c25" />

## After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ee540b14-1c44-4049-b8bf-909782149e00" />

/fix #1853 