### PR TITLE
Update circuit-json-to-gerber

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/runframe",
@@ -41,7 +40,7 @@
         "chokidar-cli": "^3.0.0",
         "circuit-json": "0.0.303",
         "circuit-json-to-bom-csv": "^0.0.8",
-        "circuit-json-to-gerber": "^0.0.37",
+        "circuit-json-to-gerber": "^0.0.41",
         "circuit-json-to-gltf": "^0.0.41",
         "circuit-json-to-kicad": "^0.0.25",
         "circuit-json-to-lbrn": "^0.0.4",
@@ -699,7 +698,7 @@
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.22", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg=="],
 
-    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.37", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.2", "fast-json-stable-stringify": "^2.1.0", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-S4fjLblZxJs0MkSU18WzIlTXe4q+cI8lBPO/VSMXy3bV+YzaxBMuttN5Zl5/iZNZZCQ4zOZFdZuCiwS0EvDeYQ=="],
+    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.41", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.2", "fast-json-stable-stringify": "^2.1.0", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-KeaEEcdMvNaj76Lx7p94JvvRep3lBIZ3OTKAHQIhyAxIDP9shqiQcgWzOUjPFMP5K/gQ4UM4RscMUiZqnsfDGg=="],
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.41", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "jscad-electronics": "^0.0.53", "jscad-to-gltf": "^0.0.5" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-pSZeKKgkmj+tJXfpzGzzKK29lAMHE1YuyTEXhh3hssXcBv8B2qR208VCXDTKuNMQ2dEquueuyqznZE+KC4rqMw=="],
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chokidar-cli": "^3.0.0",
     "circuit-json": "0.0.303",
     "circuit-json-to-bom-csv": "^0.0.8",
-    "circuit-json-to-gerber": "^0.0.37",
+    "circuit-json-to-gerber": "^0.0.41",
     "circuit-json-to-gltf": "^0.0.41",
     "circuit-json-to-kicad": "^0.0.25",
     "circuit-json-to-lbrn": "^0.0.4",


### PR DESCRIPTION
## Summary
- update circuit-json-to-gerber to version 0.0.41
- refresh bun.lock with new dependency metadata

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692cffd7758c832e97e3e1128145474f)