### PR TITLE
Include version in automated bump PR messages

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -34,12 +34,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
+      - name: Get package version
+        id: get-version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "chore: bump version"
-          title: "chore: bump version"
+          commit-message: "chore: bump version v${{ steps.get-version.outputs.version }}"
+          title: "chore: bump version v${{ steps.get-version.outputs.version }}"
           body: "Automated package update"
           branch: bump-version-${{ github.run_number }}
           base: main


### PR DESCRIPTION
## Summary
- capture the package version after running `pver release`
- include the version number in the automated bump PR commit message and title

## Testing
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f851a8c78832e9a4658284292bff0)