### PR TITLE
Fix version output step in release workflow

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Get package version
         id: get-version
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
## Summary
- update version output step to use a multiline script for clearer quoting
- write the resolved package version to the GitHub output file

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930d1cf8408832eae643b5ba872c4c0)