### PR TITLE
Load EasyEDA converter from jsdelivr on demand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/runframe",
@@ -55,7 +54,6 @@
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
         "debug": "^4.4.0",
-        "easyeda": "^0.0.228",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -860,8 +858,6 @@
     "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
-    "easyeda": ["easyeda@0.0.228", "", { "peerDependencies": { "tscircuit": "^0.0.571", "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-rDzfAxcVL6qjYlBjBJpExDRt//TbzC4oD/NO4tcSBCYvkfASPqt7HeoUQUM83kV6bL0SpV+R4+0t34c6Y43wbQ=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/lib/components/ImportComponentDialog2/api/jlcpcb.ts
+++ b/lib/components/ImportComponentDialog2/api/jlcpcb.ts
@@ -1,5 +1,5 @@
-import { fetchEasyEDAComponent, convertRawEasyToTsx } from "easyeda/browser"
 import { API_BASE } from "lib/components/RunFrameWithApi/api-base"
+import { loadEasyedaBrowser } from "lib/optional-features/importing/load-easyeda-browser"
 import type { JlcpcbComponentSummary } from "../types"
 
 interface JlcpcbComponentApiResult {
@@ -48,6 +48,9 @@ export const loadJlcpcbComponentTsx = async (
   partNumber: string,
   opts?: { headers?: Record<string, string>; apiBase?: string },
 ): Promise<string> => {
+  const { fetchEasyEDAComponent, convertRawEasyToTsx } =
+    await loadEasyedaBrowser()
+
   const component = await fetchEasyEDAComponent(partNumber, {
     // @ts-ignore
     fetch: (url, options: RequestInit & { headers?: Record<string, string> }) =>

--- a/lib/optional-features/importing/import-component-from-jlcpcb.ts
+++ b/lib/optional-features/importing/import-component-from-jlcpcb.ts
@@ -1,11 +1,14 @@
-import { fetchEasyEDAComponent, convertRawEasyToTsx } from "easyeda/browser"
 import { API_BASE } from "lib/components/RunFrameWithApi/api-base"
+import { loadEasyedaBrowser } from "./load-easyeda-browser"
 import ky from "ky"
 
 export const importComponentFromJlcpcb = async (
   jlcpcbPartNumber: string,
   opts?: { headers?: Record<string, string> },
 ) => {
+  const { fetchEasyEDAComponent, convertRawEasyToTsx } =
+    await loadEasyedaBrowser()
+
   const component = await fetchEasyEDAComponent(jlcpcbPartNumber, {
     // @ts-ignore
     fetch: (url, options: any) => {

--- a/lib/optional-features/importing/load-easyeda-browser.ts
+++ b/lib/optional-features/importing/load-easyeda-browser.ts
@@ -1,0 +1,24 @@
+const EASYEDA_BROWSER_URL =
+  "https://cdn.jsdelivr.net/npm/easyeda@0.0.228/dist/browser/index.js"
+
+type EasyedaBrowserModule = {
+  fetchEasyEDAComponent: (
+    partNumber: string,
+    options?: {
+      fetch?: (url: RequestInfo, init?: RequestInit) => Promise<Response>
+    },
+  ) => Promise<any>
+  convertRawEasyToTsx: (component: any) => Promise<string>
+}
+
+let easyedaBrowserPromise: Promise<EasyedaBrowserModule> | null = null
+
+export const loadEasyedaBrowser = async (): Promise<EasyedaBrowserModule> => {
+  if (!easyedaBrowserPromise) {
+    easyedaBrowserPromise = import(
+      /* @vite-ignore */ EASYEDA_BROWSER_URL
+    ) as Promise<EasyedaBrowserModule>
+  }
+
+  return easyedaBrowserPromise
+}

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
     "debug": "^4.4.0",
-    "easyeda": "^0.0.228",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary
- remove the direct easyeda dependency from the package configuration
- add a helper to dynamically load the EasyEDA browser module from jsdelivr
- update JLCPCB import flows to request the EasyEDA converter only when needed

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69338c59f338832eb303918212b4f3b3)