### PR TITLE
Load EasyEDA browser from latest tag

### DIFF
--- a/lib/optional-features/importing/load-easyeda-browser.ts
+++ b/lib/optional-features/importing/load-easyeda-browser.ts
@@ -1,5 +1,5 @@
 const EASYEDA_BROWSER_URL =
-  "https://cdn.jsdelivr.net/npm/easyeda@0.0.228/dist/browser/index.js"
+  "https://cdn.jsdelivr.net/npm/easyeda@latest/dist/browser/index.js"
 
 type EasyedaBrowserModule = {
   fetchEasyEDAComponent: (


### PR DESCRIPTION
## Summary
- update the EasyEDA browser CDN import to use the `@latest` tag so the newest release is fetched automatically

## Testing
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933938188fc832e9afcaee539f8d185)