### PR TITLE
Added routing disabled tip

### DIFF
--- a/lib/utils/getRandomTipForUser.ts
+++ b/lib/utils/getRandomTipForUser.ts
@@ -21,7 +21,7 @@ export const tips = [
   "Check out the [GitHub Discussions page](https://github.com/tscircuit/tscircuit/discussions) to upvote features",
   "You can customize the autorouter using the [autorouter prop](https://docs.tscircuit.com/elements/board#setting-the-autorouter)",
   "Use the [<constraint />](https://docs.tscircuit.com/footprints/constraint) element to enforce geometric relationships in PCB designs.",
-  "When working on component placement and circuit design, autorouting can slow down your iteration cycle. Use routingDisabled on the <board /> element to disable autorouting temporarily.",
+  "When working on component placement and circuit design, autorouting can slow down your iteration cycle. Use [routingDisabled](https://docs.tscircuit.com/elements/board#disabling-routing-with-routingdisabled) on the <board /> element to disable autorouting temporarily.",
   "Join the [Discord server](https://tscircuit.com/join) to discuss issues and get help directly from the community.",
 ]
 


### PR DESCRIPTION
This pull request adds a new user tip to the `tips` array in `lib/utils/getRandomTipForUser.ts`. The new tip informs users that they can temporarily disable autorouting during component placement and circuit design by using the `routingDisabled` prop on the `<board />` element. This helps speed up iteration cycles.

Tip: "When working on component placement and circuit design, autorouting can slow down your iteration cycle. Use [routingDisabled](https://docs.tscircuit.com/elements/board#disabling-routing-with-routingdisabled) on the <board /> element to disable autorouting temporarily."

Hey @seveibar  , can we please add this tip, this helped me a lot when developing sparkfun boards