### PR TITLE
Add solver debugging tab for solver events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,9 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/runframe",
+      "dependencies": {
+        "@tscircuit/capacity-autorouter": "^0.0.181",
+        "@tscircuit/solver-utils": "^0.0.4",
+      },
       "devDependencies": {
         "@babel/standalone": "^7.26.10",
         "@biomejs/biome": "^1.9.4",
@@ -27,7 +30,7 @@
         "@tscircuit/file-server": "^0.0.32",
         "@tscircuit/footprinter": "^0.0.236",
         "@tscircuit/math-utils": "^0.0.25",
-        "@tscircuit/pcb-viewer": "^1.11.283",
+        "@tscircuit/pcb-viewer": "1.11.283",
         "@tscircuit/props": "^0.0.397",
         "@tscircuit/schematic-trace-solver": "^0.0.40",
         "@tscircuit/schematic-viewer": "2.0.49",
@@ -457,7 +460,7 @@
 
     "@tscircuit/assembly-viewer": ["@tscircuit/assembly-viewer@0.0.5", "", { "dependencies": { "debug": "^4.4.0", "performance-now": "^2.1.0", "use-mouse-matrix-transform": "^1.2.2" }, "peerDependencies": { "@tscircuit/core": "*", "@tscircuit/props": "*", "circuit-to-svg": "*", "typescript": "^5.0.0" } }, "sha512-8dI0ZTym79SPjYgh2lNPZi3R7fvIqjTMypT9756Htp2NxW1717QQvNBAP7L44pNyyL7p/G/BsOnjbDe4tW+gPQ=="],
 
-    "@tscircuit/capacity-autorouter": ["@tscircuit/capacity-autorouter@0.0.107", "", { "dependencies": { "fast-json-stable-stringify": "^2.1.0", "object-hash": "^3.0.0" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-b4LTylZnrLrv0YQU615A4yzNJUt+/p5JWLBZgy+9IzIA7Q/ObYhpq+9rX/HLZ074T8rGxj1bV6z1g4cdSvdxFw=="],
+    "@tscircuit/capacity-autorouter": ["@tscircuit/capacity-autorouter@0.0.181", "", { "dependencies": { "bun-match-svg": "^0.0.14", "fast-json-stable-stringify": "^2.1.0", "object-hash": "^3.0.0" } }, "sha512-/ym8kIVK4P5VXkqRtS0zidJ+SWUUWHMrDLo8Ob25pf08kvG8yMCKqqy13AvrcxV11/lOix9sSqH6W5L/L3qjcA=="],
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.78", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-mme5imlnDvNpb0ItGGxBV4JAY1VoSdRge0YNNA3/eEEHDpB7xWP1kYyg9ZIPDiKSPspziscFbKp7ajBFrh96LQ=="],
 
@@ -506,6 +509,8 @@
     "@tscircuit/schematic-viewer": ["@tscircuit/schematic-viewer@2.0.49", "", { "dependencies": { "chart.js": "^4.5.0", "circuit-json-to-spice": "^0.0.10", "debug": "^4.4.0", "performance-now": "^2.1.0", "react-chartjs-2": "^5.3.0", "use-mouse-matrix-transform": "^1.2.2" }, "peerDependencies": { "tscircuit": "*", "typescript": "^5.0.0" } }, "sha512-XEX3NhY4gycQYPHmbOSIWAa6hbe+R1VNzxlhE7hDCUisCHVIaiS68Gvv/L6FS8l5m6rt5WYy3A754W8oNTVf3Q=="],
 
     "@tscircuit/simple-3d-svg": ["@tscircuit/simple-3d-svg@0.0.41", "", { "dependencies": { "fast-xml-parser": "^5.2.5", "fflate": "^0.8.2" } }, "sha512-2iwhHhMLElq5t0fcC0Gr7cCpZhEOAKh+6NN0NIJ9YWUCcsB7UN8uYko7jqNTxDlYOe6E0ZYaDZWsQ3amOZ3dlw=="],
+
+    "@tscircuit/solver-utils": ["@tscircuit/solver-utils@0.0.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-c/qVGyMjodlyLJ5UpAjCIOH7Br3aIPrDB1kKirIRzXO9fXSOKRrwZwqHqjnxqmKY2aa9/e+a8V/jEYJgnT6pow=="],
 
     "@tscircuit/soup-util": ["@tscircuit/soup-util@0.0.41", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "*" } }, "sha512-47JKWBUKkRVHhad0HhBbdOJxB6v/eiac46beiKRBMlJqiZ1gPGI276v9iZfpF7c4hXR69cURcgiwuA5vowrFEg=="],
 
@@ -645,7 +650,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-match-svg": ["bun-match-svg@0.0.9", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-WISE8cUd3ztIEbYRymuxs+l4qwRviHIhyRQHmDz26vnhKON9g+Ur+2L3pfJrffpGiYWGF/jtWoWmYRQiaimTxg=="],
+    "bun-match-svg": ["bun-match-svg@0.0.14", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-6tiAOY70cwf0aptY/0etMa3/8W1JggJBk3odwPhLhcUABoS3gaEbfYe8hE2z3o/tcbZ/imcmKz94c3T/ht7M+Q=="],
 
     "bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
 
@@ -1899,6 +1904,8 @@
 
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
+    "graphics-debug/bun-match-svg": ["bun-match-svg@0.0.9", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-WISE8cUd3ztIEbYRymuxs+l4qwRviHIhyRQHmDz26vnhKON9g+Ur+2L3pfJrffpGiYWGF/jtWoWmYRQiaimTxg=="],
+
     "graphics-debug/transformation-matrix": ["transformation-matrix@3.1.0", "", {}, "sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA=="],
 
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -1986,6 +1993,8 @@
     "temp/rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
 
     "three-stdlib/fflate": ["fflate@0.6.10", "", {}, "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="],
+
+    "tscircuit/@tscircuit/capacity-autorouter": ["@tscircuit/capacity-autorouter@0.0.107", "", { "dependencies": { "fast-json-stable-stringify": "^2.1.0", "object-hash": "^3.0.0" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-b4LTylZnrLrv0YQU615A4yzNJUt+/p5JWLBZgy+9IzIA7Q/ObYhpq+9rX/HLZ074T8rGxj1bV6z1g4cdSvdxFw=="],
 
     "tscircuit/@tscircuit/checks": ["@tscircuit/checks@0.0.75", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-fNSQTEW6OdXJqkDBycq65FfnqRXY+08Zx37np71grQb/rCAAQdn59pKc+dJBuiBbN/V56aLnPy2lx+HzXyWKAw=="],
 

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -1,6 +1,7 @@
 import type { RenderLog } from "lib/render-logging/RenderLog"
 import type { ManualEditEvent } from "@tscircuit/props"
 import type { CircuitJson } from "circuit-json"
+import type { SolverStartedEvent } from "lib/types/solver-events"
 
 export type TabId =
   | "code"
@@ -13,6 +14,7 @@ export type TabId =
   | "circuit_json"
   | "errors"
   | "render_log"
+  | "solvers"
 
 export interface PreviewContentProps {
   defaultToFullScreen?: boolean
@@ -110,4 +112,6 @@ export interface PreviewContentProps {
    * Callback to rerun render with debug options
    */
   onRerunWithDebug?: (debugOption: string) => void
+
+  solverEvents?: SolverStartedEvent[]
 }

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -46,6 +46,7 @@ import {
   buildRunCompletedPayload,
   type RunCompletedPayload,
 } from "./run-completion"
+import type { SolverStartedEvent } from "../../types/solver-events"
 
 const fetchLatestEvalVersion = async () => {
   try {
@@ -187,6 +188,7 @@ export const RunFrame = (props: RunFrameProps) => {
 
   const [renderLog, setRenderLog] = useState<RenderLog | null>(null)
   const [autoroutingLog, setAutoroutingLog] = useState<Record<string, any>>({})
+  const [solverEvents, setSolverEvents] = useState<SolverStartedEvent[]>([])
   const [activeTab, setActiveTab] = useState<TabId>(
     props.defaultActiveTab ?? props.defaultTab ?? "pcb",
   )
@@ -253,6 +255,7 @@ export const RunFrame = (props: RunFrameProps) => {
       setError(null)
       setRenderLog(null)
       setActiveAsyncEffects({})
+      setSolverEvents([])
       const renderLog: RenderLog = { progress: 0, debugOutputs: [] }
       let cancelled = false
 
@@ -322,6 +325,9 @@ export const RunFrame = (props: RunFrameProps) => {
             simpleRouteJson: event.simpleRouteJson,
           },
         })
+      })
+      worker.on("solver:started" as any, (event: SolverStartedEvent) => {
+        setSolverEvents((existing) => [...existing, event])
       })
       worker.on("board:renderPhaseStarted", (event: any) => {
         renderLog.lastRenderEvent = event
@@ -632,6 +638,7 @@ export const RunFrame = (props: RunFrameProps) => {
         onActiveTabChange={setActiveTab}
         circuitJson={circuitJson}
         renderLog={renderLog}
+        solverEvents={solverEvents}
         activeEffectName={activeEffectName}
         isRunningCode={isRunning}
         errorMessage={error?.error}

--- a/lib/types/solver-events.ts
+++ b/lib/types/solver-events.ts
@@ -1,0 +1,6 @@
+export interface SolverStartedEvent {
+  type: "solver:started"
+  solverName: string
+  solverParams: unknown
+  componentName: string
+}

--- a/lib/utils/create-solver-from-event.ts
+++ b/lib/utils/create-solver-from-event.ts
@@ -1,0 +1,70 @@
+import { PackSolver2 } from "calculate-packing"
+import {
+  AssignableViaAutoroutingPipelineSolver,
+  AutoroutingPipelineSolver,
+} from "@tscircuit/capacity-autorouter"
+import type { BaseSolver } from "@tscircuit/solver-utils"
+import type { SolverStartedEvent } from "lib/types/solver-events"
+
+const SOLVER_CLASSES = {
+  PackSolver2,
+  AutoroutingPipelineSolver,
+  AssignableViaAutoroutingPipelineSolver,
+} as const
+
+type SupportedSolverName = keyof typeof SOLVER_CLASSES
+
+const getSolverConstructor = (solverName: string) =>
+  SOLVER_CLASSES[solverName as SupportedSolverName]
+
+export const createSolverFromEvent = (
+  event: SolverStartedEvent,
+): { solver: BaseSolver | null; error: string | null } => {
+  const SolverClass = getSolverConstructor(event.solverName)
+
+  if (!SolverClass) {
+    return {
+      solver: null,
+      error: `Solver "${event.solverName}" is not currently supported in this viewer`,
+    }
+  }
+
+  try {
+    const params = event.solverParams as any
+    const SolverCtor = SolverClass as unknown as new (
+      ...args: any[]
+    ) => BaseSolver
+
+    if (Array.isArray(params)) {
+      return {
+        solver: new SolverCtor(...params),
+        error: null,
+      }
+    }
+
+    if (params && typeof params === "object" && "input" in params) {
+      return {
+        solver: new SolverCtor((params as any).input, (params as any).options),
+        error: null,
+      }
+    }
+
+    if (params === undefined || params === null) {
+      return { solver: new SolverCtor(params), error: null }
+    }
+
+    return { solver: new SolverCtor(params), error: null }
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unknown error constructing solver"
+
+    return {
+      solver: null,
+      error: `Failed to construct solver: ${message}`,
+    }
+  }
+}
+
+export type { SupportedSolverName }

--- a/package.json
+++ b/package.json
@@ -117,5 +117,9 @@
     "tsup": "^8.3.5",
     "vite": "^7.1.2",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "@tscircuit/capacity-autorouter": "^0.0.181",
+    "@tscircuit/solver-utils": "^0.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- track `solver:started` events during runs and reset them each execution
- add a Solvers tab that lists started solvers, shows parameters, and renders them in `GenericSolverDebugger`
- add helper utilities and dependencies to reconstruct solvers from event payloads

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c8fe69224832e90e5e441538f3e0b)