### PR TITLE
Add Analog Simulation tab and example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "@tscircuit/pcb-viewer": "1.11.289",
         "@tscircuit/props": "^0.0.429",
         "@tscircuit/schematic-trace-solver": "^0.0.40",
-        "@tscircuit/schematic-viewer": "2.0.49",
+        "@tscircuit/schematic-viewer": "2.0.50",
         "@types/bun": "latest",
         "@types/debug": "^4.1.12",
         "@types/react": "^19.1.10",
@@ -523,7 +523,7 @@
 
     "@tscircuit/schematic-trace-solver": ["@tscircuit/schematic-trace-solver@0.0.40", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-wZxP623ANy1YU6L4BIxwHTHijXC+lSv6TaWiBEoLlTK696tbeSNgHhu4fnBrDoFW+Yr8y4ZkOJOKNNYCt+AYhw=="],
 
-    "@tscircuit/schematic-viewer": ["@tscircuit/schematic-viewer@2.0.49", "", { "dependencies": { "chart.js": "^4.5.0", "circuit-json-to-spice": "^0.0.10", "debug": "^4.4.0", "performance-now": "^2.1.0", "react-chartjs-2": "^5.3.0", "use-mouse-matrix-transform": "^1.2.2" }, "peerDependencies": { "tscircuit": "*", "typescript": "^5.0.0" } }, "sha512-XEX3NhY4gycQYPHmbOSIWAa6hbe+R1VNzxlhE7hDCUisCHVIaiS68Gvv/L6FS8l5m6rt5WYy3A754W8oNTVf3Q=="],
+    "@tscircuit/schematic-viewer": ["@tscircuit/schematic-viewer@2.0.50", "", { "dependencies": { "chart.js": "^4.5.0", "circuit-json-to-spice": "^0.0.30", "debug": "^4.4.0", "performance-now": "^2.1.0", "react-chartjs-2": "^5.3.0", "use-mouse-matrix-transform": "^1.2.2" }, "peerDependencies": { "tscircuit": "*", "typescript": "^5.0.0" } }, "sha512-JUkioTIYm8vrtTwXcdKV+w9MUw9Wo7DP6e5wIEHwOUfhdqW8BaEsBKZPOJZCPS47pHCkvHPn8bTnH5rPHkhiEw=="],
 
     "@tscircuit/simple-3d-svg": ["@tscircuit/simple-3d-svg@0.0.41", "", { "dependencies": { "fast-xml-parser": "^5.2.5", "fflate": "^0.8.2" } }, "sha512-2iwhHhMLElq5t0fcC0Gr7cCpZhEOAKh+6NN0NIJ9YWUCcsB7UN8uYko7jqNTxDlYOe6E0ZYaDZWsQ3amOZ3dlw=="],
 
@@ -737,7 +737,7 @@
 
     "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.9", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-thpCtDb9LpAQfGO+Z0hae19sxVAmJAMYM/It9UTMCtyXC3zoUHwRcp/oqtMO/ZIW+JDBhiR8AHmmtKScL2kW7Q=="],
 
-    "circuit-json-to-spice": ["circuit-json-to-spice@0.0.10", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.41", "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-2E83zXsv23lTlfPryKsW3kxKNvYI+IeMAFTZ77SPp4VjHapBmnGBAqFN1TgEEfwUeGjIE+i7ven6mL2W+vcUlA=="],
+    "circuit-json-to-spice": ["circuit-json-to-spice@0.0.30", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-ArMfJhxh7lWI1OiZLMNBong7r3tArX9Q6JOprDPirku0bUZwLXr5AY4w/pDlkEivlaRX6yvamqebWja6yIONog=="],
 
     "circuit-json-to-step": ["circuit-json-to-step@0.0.11", "", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.72", "circuit-json-to-connectivity-map": "^0.0.22", "circuit-json-to-gltf": "^0.0.19", "circuit-to-svg": "^0.0.248", "schematic-symbols": "^0.0.202" }, "peerDependencies": { "typescript": "^5" } }, "sha512-3fYoPsnWUfX1BZNP5ku6EZSuHf9278PWb301kxbLGHDWM2ydsKz9rA2zupK4Hru9Xl4uccEDszpVOf8d+05lcA=="],
 
@@ -2067,8 +2067,6 @@
 
     "tscircuit/circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.31", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "jscad-electronics": "^0.0.53", "jscad-to-gltf": "^0.0.5" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-TJ2yT7Ph//UyCt5u5W6PdyvAxil3Opy25hzzwRheqTw+UMo2WhcY6oug6svjPmaGyjjN6fhl0eMeoUgcfgq3sQ=="],
 
-    "tscircuit/circuit-json-to-spice": ["circuit-json-to-spice@0.0.30", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-ArMfJhxh7lWI1OiZLMNBong7r3tArX9Q6JOprDPirku0bUZwLXr5AY4w/pDlkEivlaRX6yvamqebWja6yIONog=="],
-
     "tscircuit/kicad-to-circuit-json": ["kicad-to-circuit-json@0.0.15", "", { "dependencies": { "schematic-symbols": "^0.0.202" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HG9OVhHqitW08MHX1wFCSF6WPi1EFkywgJJt6qqTpMeZFe211qpctNQbyDpYvlS/u5YTn2h208aCqY8W8DBNHw=="],
 
     "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
@@ -2183,8 +2181,6 @@
 
     "tscircuit/circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
 
-    "tscircuit/circuit-json-to-spice/circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.22", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg=="],
-
     "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -2274,8 +2270,6 @@
     "source-map-explorer/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "temp/rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
-    "tscircuit/circuit-json-to-spice/circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
 
     "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/examples/example43-simulation-view.fixture.tsx
+++ b/examples/example43-simulation-view.fixture.tsx
@@ -1,0 +1,139 @@
+import React from "react"
+import * as Core from "@tscircuit/core"
+import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
+import { CircuitJsonPreview } from "lib/preview"
+
+// TSX circuit definition
+const SwitchCircuitElement = (
+  <board schMaxTraceDistance={10} routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R_base" resistance="10k" schY={2} />
+    <switch name="SW1" simSwitchFrequency="1kHz" schX={1.5} schY={2} />
+    <transistor
+      name="Q1"
+      type="npn"
+      footprint="sot23"
+      schX={2}
+      schY={0.3}
+      schRotation={180}
+    />
+    <resistor name="R_collector" resistance="10k" schY={-2} />
+
+    <trace from=".V1 > .pin1" to=".R_base > .pin1" />
+    <trace from=".R_base > .pin2" to=".SW1 > .pin1" />
+    <trace from=".SW1 > .pin2" to=".Q1 > .base" />
+
+    <trace from=".V1 > .pin1" to=".R_collector > .pin1" />
+    <trace from=".R_collector > .pin2" to=".Q1 > .collector" />
+
+    <trace from=".Q1 > .emitter" to=".V1 > .pin2" />
+
+    <voltageprobe name="VP_COLLECTOR" connectsTo=".R_collector > .pin2" />
+
+    <analogsimulation duration="4ms" timePerStep="1us" spiceEngine="ngspice" />
+  </board>
+)
+
+// Convert TSX to CircuitJSON and add simulation data
+const createSimulatedCircuitJson = async () => {
+  try {
+    // Step 1: Create circuit with platform configuration
+    const circuit = new Core.Circuit()
+
+    const ngspiceEngine = await createNgspiceSpiceEngine()
+    circuit.setPlatform({
+      spiceEngineMap: {
+        ngspice: ngspiceEngine,
+      },
+    })
+
+    // Step 2: Add the circuit element
+    circuit.add(SwitchCircuitElement)
+    await circuit.renderUntilSettled()
+
+    // Step 3: Get CircuitJSON (includes simulation data if produced by the platform)
+    return circuit.getCircuitJson()
+  } catch (error) {
+    console.error("Simulation failed:", error)
+    // Return basic CircuitJSON if simulation fails
+    const fallbackCircuit = new Core.Circuit()
+    fallbackCircuit.add(SwitchCircuitElement)
+    await fallbackCircuit.renderUntilSettled()
+    return fallbackCircuit.getCircuitJson()
+  }
+}
+
+export default () => {
+  const [simulatedCircuitJson, setSimulatedCircuitJson] = React.useState<
+    any[] | null
+  >(null)
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    const loadAndSimulateCircuit = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+
+        const result = await createSimulatedCircuitJson()
+        setSimulatedCircuitJson(result)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load circuit")
+        console.error("Error loading circuit:", err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadAndSimulateCircuit()
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center" }}>
+        <h2>Analog Simulation Viewer Example</h2>
+        <p>Converting TSX to CircuitJSON and running SPICE simulation...</p>
+        <div
+          style={{
+            display: "inline-block",
+            padding: "20px",
+            backgroundColor: "#f5f5f5",
+            borderRadius: "8px",
+            marginTop: "20px",
+          }}
+        >
+          Loading and simulating circuit...
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center" }}>
+        <h2>Analog Simulation Viewer Example</h2>
+        <div
+          style={{
+            display: "inline-block",
+            padding: "20px",
+            backgroundColor: "#fef2f2",
+            borderRadius: "8px",
+            border: "1px solid #fecaca",
+            color: "#dc2626",
+            marginTop: "20px",
+          }}
+        >
+          <h4>Error:</h4>
+          <p>{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    simulatedCircuitJson && (
+      <CircuitJsonPreview circuitJson={simulatedCircuitJson} />
+    )
+  )
+}

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -15,6 +15,7 @@ import { AssemblyViewer, PinoutViewer } from "@tscircuit/assembly-viewer"
 import PreviewEmptyState from "../PreviewEmptyState"
 import { CircuitJsonTableViewer } from "../CircuitJsonTableViewer/CircuitJsonTableViewer"
 import { BomTable } from "../BomTable"
+import { AnalogSimulationViewer } from "@tscircuit/schematic-viewer"
 import {
   CheckIcon,
   EllipsisIcon,
@@ -65,6 +66,7 @@ declare global {
 const dropdownMenuItems = [
   "assembly",
   "pinout",
+  "analog_simulation",
   "bom",
   "circuit_json",
   "errors",
@@ -642,6 +644,34 @@ export const CircuitJsonPreview = ({
                       ref={setCadViewerRef}
                       circuitJson={circuitJson as any}
                       autoRotateDisabled={autoRotate3dViewerDisabled}
+                    />
+                  ) : (
+                    <PreviewEmptyState onRunClicked={onRunClicked} />
+                  )}
+                </ErrorBoundary>
+              </div>
+            </TabsContent>
+          )}
+
+          {(!availableTabs || availableTabs.includes("analog_simulation")) && (
+            <TabsContent value="analog_simulation">
+              <div
+                className={cn(
+                  "rf-overflow-auto",
+                  isFullScreen
+                    ? "rf-h-[calc(100vh-60px)]"
+                    : "rf-h-full  rf-min-h-[620px]",
+                )}
+              >
+                <ErrorBoundary
+                  fallback={<div>Error loading Analog Simulation</div>}
+                >
+                  {circuitJson ? (
+                    <AnalogSimulationViewer
+                      circuitJson={circuitJson}
+                      containerStyle={{
+                        height: "100%",
+                      }}
                     />
                   ) : (
                     <PreviewEmptyState onRunClicked={onRunClicked} />

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -16,6 +16,7 @@ export type TabId =
   | "assembly"
   | "pinout"
   | "cad"
+  | "analog_simulation"
   | "bom"
   | "circuit_json"
   | "errors"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tscircuit/pcb-viewer": "1.11.289",
     "@tscircuit/props": "^0.0.429",
     "@tscircuit/schematic-trace-solver": "^0.0.40",
-    "@tscircuit/schematic-viewer": "2.0.49",
+    "@tscircuit/schematic-viewer": "2.0.50",
     "@types/bun": "latest",
     "@types/debug": "^4.1.12",
     "@types/react": "^19.1.10",


### PR DESCRIPTION
This pull request introduces an analog simulation viewing capability to the circuit preview workflow. The main change is the integration of an "Analog Simulation" tab in the `CircuitJsonPreview` component, which allows users to view analog simulation results directly from CircuitJSON data. Additionally, a new fixture demonstrates how to convert a TSX circuit definition into CircuitJSON and run a SPICE simulation.

**Analog simulation integration:**

* Added the `AnalogSimulationViewer` component from `@tscircuit/schematic-viewer` to the `CircuitJsonPreview` tabs, enabling users to view analog simulation results within the preview UI. [[1]](diffhunk://#diff-dad96227df368e95476bb9cc35b92a502e727c59a25807c55e30765f28eb2e9bR18) [[2]](diffhunk://#diff-dad96227df368e95476bb9cc35b92a502e727c59a25807c55e30765f28eb2e9bR656-R683)
* Updated the available tabs and types to include the new `"analog_simulation"` tab, ensuring it appears in the UI and is recognized throughout the codebase. [[1]](diffhunk://#diff-dad96227df368e95476bb9cc35b92a502e727c59a25807c55e30765f28eb2e9bR69) [[2]](diffhunk://#diff-7921fb2cc23baac7d6e2a05ff6f89c2f595acc130c2cb3763bdea15abcebed26R19)

**Example and demonstration:**

* Added a new fixture file, `example43-simulation-view.fixture.tsx`, which demonstrates creating a TSX circuit, running a SPICE simulation using `ngspice`, and rendering the results with the new analog simulation viewer.

**Dependency update:**

* Updated the `@tscircuit/schematic-viewer` package to version `2.0.50` to ensure compatibility with the new analog simulation features.

<img width="1920" height="1052" alt="Screenshot_20251218_125959" src="https://github.com/user-attachments/assets/8c103b29-7416-4682-87d6-9f2d3d1169bc" />
