### PR TITLE
Increase GLB export board texture resolution from 512 to 1024

### DIFF
--- a/lib/optional-features/exporting/formats/export-glb.ts
+++ b/lib/optional-features/exporting/formats/export-glb.ts
@@ -14,7 +14,7 @@ export const exportGlb = async ({
     const { convertCircuitJsonToGltf } = await importer("circuit-json-to-gltf")
 
     console.log("convertCircuitJsonToGltf", convertCircuitJsonToGltf)
-    // Use lower texture resolution for better performance and compatibility
+
     const glbArrayBuffer = (await convertCircuitJsonToGltf(circuitJson, {
       format: "glb",
       boardTextureResolution: 1024,

--- a/lib/optional-features/exporting/formats/export-glb.ts
+++ b/lib/optional-features/exporting/formats/export-glb.ts
@@ -17,7 +17,7 @@ export const exportGlb = async ({
     // Use lower texture resolution for better performance and compatibility
     const glbArrayBuffer = (await convertCircuitJsonToGltf(circuitJson, {
       format: "glb",
-      boardTextureResolution: 512,
+      boardTextureResolution: 1024,
     })) as ArrayBuffer
 
     // Ensure we have a valid ArrayBuffer before creating the blob


### PR DESCRIPTION
GLB exports were forcing boardTextureResolution: 512, which made board textures lose detail; switching to 1024 fixes the missing export content.

https://discord.com/channels/1233487248129921135/1490585777149575168