### PR TITLE
Fix KiCad footprint mapping to use slash paths

### DIFF
--- a/lib/components/ImportComponentDialog/kicad-api.ts
+++ b/lib/components/ImportComponentDialog/kicad-api.ts
@@ -41,7 +41,7 @@ export const mapKicadFootprintToSearchResult = (
   footprintPath: string,
 ): ComponentSearchResult => {
   const cleanedFootprint = footprintPath
-    .replace(".pretty/", ":")
+    .replace(".pretty/", "/")
     .replace(".kicad_mod", "")
   const footprintString = `kicad:${cleanedFootprint}`
 

--- a/lib/components/ImportComponentDialog2/api/kicad.ts
+++ b/lib/components/ImportComponentDialog2/api/kicad.ts
@@ -40,7 +40,7 @@ export const mapKicadFootprintToSummary = (
   footprintPath: string,
 ): KicadFootprintSummary => {
   const cleanedFootprint = footprintPath
-    .replace(".pretty/", ":")
+    .replace(".pretty/", "/")
     .replace(".kicad_mod", "")
   const footprintString = `kicad:${cleanedFootprint}`
 


### PR DESCRIPTION
Motivation:
Kicad footprint format is copied with colon but the eval/core expects that to be in slash(/). 


https://github.com/user-attachments/assets/7135a4a3-e7bf-4a98-9ff2-453ae41fd894


<img width="1682" height="310" alt="image" src="https://github.com/user-attachments/assets/2e75003b-b42d-435f-b28b-00668ff17c1d" />



KiCad footprints were being mapped from .pretty / to : which breaks the expected kicad:Lib/Footprint format. 
This patch keeps / so imports and search results match real KiCad paths.

https://github.com/user-attachments/assets/f3b7d3d0-e056-4d7f-8c7a-57ff99d064e8