### PR TITLE
Remove redundant circuitJson casts in preview viewers

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -525,7 +525,7 @@ export const CircuitJsonPreview = ({
                   {circuitJson ? (
                     <PcbViewerWithContainerHeight
                       focusOnHover={false}
-                      circuitJson={circuitJson as any}
+                      circuitJson={circuitJson}
                       debugGraphics={autoroutingGraphics}
                       containerClassName={cn(
                         "rf-h-full rf-w-full",
@@ -684,7 +684,7 @@ export const CircuitJsonPreview = ({
                     <CadViewer
                       key={`cad-${isFullScreen}`}
                       ref={setCadViewerRef}
-                      circuitJson={circuitJson as any}
+                      circuitJson={circuitJson}
                       autoRotateDisabled={autoRotate3dViewerDisabled}
                     />
                   ) : (
@@ -768,7 +768,7 @@ export const CircuitJsonPreview = ({
               >
                 <ErrorBoundary fallback={<div>Error loading JSON viewer</div>}>
                   {circuitJson ? (
-                    <CircuitJsonTableViewer elements={circuitJson as any} />
+                    <CircuitJsonTableViewer elements={circuitJson} />
                   ) : (
                     <PreviewEmptyState onRunClicked={onRunClicked} />
                   )}


### PR DESCRIPTION
## What changed

Removed redundant `as any` casts when passing `circuitJson` into the preview viewers in `CircuitJsonPreview`.

Updated:
- `PcbViewerWithContainerHeight`
- `CadViewer`
- `CircuitJsonTableViewer`

## Why

`circuitJson` is already typed as `CircuitJson | null` in this component, so these casts were hiding type information instead of helping. Removing them makes the code easier to reason about and preserves stronger type checking at the call sites.

## Impact

- Improves type safety in the preview layer
- Reduces unnecessary `any` usage
- Makes future type regressions easier to catch

## Root cause

These casts were likely added as a shortcut during integration, even though the surrounding component already had enough type information for these props.

## Validation

- Reviewed the local diff
- Ran `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- No runtime behavior changes intended