### PR TITLE
chore: bump circuit-json-to-kicad to ^0.0.109

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/runframe",
@@ -42,7 +41,7 @@
         "chokidar-cli": "^3.0.0",
         "circuit-json-to-bom-csv": "^0.0.8",
         "circuit-json-to-gerber": "^0.0.48",
-        "circuit-json-to-kicad": "^0.0.105",
+        "circuit-json-to-kicad": "^0.0.109",
         "circuit-json-to-lbrn": "^0.0.4",
         "circuit-json-to-pnp-csv": "^0.0.7",
         "circuit-json-to-step": "^0.0.18",
@@ -781,7 +780,7 @@
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.62", "https://registry.npmmirror.com/circuit-json-to-gltf/-/circuit-json-to-gltf-0.0.62.tgz", { "dependencies": { "@jscad/modeling": "^2.12.6", "jscad-electronics": "^0.0.113", "jscad-to-gltf": "^0.0.5" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-TwI8NtvLVNDhCJg1mOB83Gdjv9/kod7yrQsr67x2JKgAFwwdND8/w6JCCN2peB4mOW9gomrnKAT23DqUzQPXng=="],
 
-    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.105", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-K5cvgQDmYDbYAUrMPvcZlr588RXoo04vBUcivgzmL+zWilcBb01OOSUvzRmQN0GqN1E6qhhaPemPNTSFdPPvsw=="],
+    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.109", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-c3Y/yOLpXbkfCyipDhbNACfFf4cchVHBTTcLOf3UPiFPK+oLyjZsNypBujgFLhr7+92DjdiKPqHNVRUMHIyq1A=="],
 
     "circuit-json-to-lbrn": ["circuit-json-to-lbrn@0.0.4", "", { "dependencies": { "lbrnts": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-CGh+w3GsB5lxF5JJdARKhXDc6QFCTRKoIB68mCyDqbxSpLAGoBakXDOKBs7TaFOrparWxMiC9YU09E41dvxN0w=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chokidar-cli": "^3.0.0",
     "circuit-json-to-bom-csv": "^0.0.8",
     "circuit-json-to-gerber": "^0.0.48",
-    "circuit-json-to-kicad": "^0.0.105",
+    "circuit-json-to-kicad": "^0.0.109",
     "circuit-json-to-lbrn": "^0.0.4",
     "circuit-json-to-pnp-csv": "^0.0.7",
     "circuit-json-to-step": "^0.0.18",


### PR DESCRIPTION
### Motivation
- Keep the workspace dependencies up-to-date by upgrading `circuit-json-to-kicad` to a newer patch version for bug fixes and improvements.

### Description
- Updated `devDependencies` entry for `circuit-json-to-kicad` in `package.json` from `^0.0.105` to `^0.0.109`.
- Regenerated `bun.lock` to pin the resolved package to `circuit-json-to-kicad@0.0.109` and updated the lockfile entry.
- Committed the changes to the repository.

### Testing
- Ran `bun add -d circuit-json-to-kicad@^0.0.109` which completed successfully.
- Verified installation with `bun pm ls circuit-json-to-kicad` which shows `circuit-json-to-kicad@0.0.109` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5a7e1c57c8327894fc513998042ec)