### PR TITLE
Fix package details dialog stacking in Import Component flow

### DIFF
--- a/lib/components/ImportComponentDialog2/ImportComponentDialog2.tsx
+++ b/lib/components/ImportComponentDialog2/ImportComponentDialog2.tsx
@@ -284,7 +284,10 @@ export const ImportComponentDialog2 = ({
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
       <DialogContent
-        style={{ width: "calc(100vw - 2rem)", zIndex: zIndexMap.importComponentDialog }}
+        style={{
+          width: "calc(100vw - 2rem)",
+          zIndex: zIndexMap.importComponentDialog,
+        }}
         className="rf-rounded-sm rf-max-h-[90vh] rf-overflow-y-auto rf-overflow-x-hidden rf-flex rf-flex-col"
       >
         <DialogHeader>

--- a/lib/components/ImportComponentDialog2/ImportComponentDialog2.tsx
+++ b/lib/components/ImportComponentDialog2/ImportComponentDialog2.tsx
@@ -284,7 +284,7 @@ export const ImportComponentDialog2 = ({
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
       <DialogContent
-        style={{ width: "calc(100vw - 2rem)", zIndex: zIndexMap.dialog }}
+        style={{ width: "calc(100vw - 2rem)", zIndex: zIndexMap.importComponentDialog }}
         className="rf-rounded-sm rf-max-h-[90vh] rf-overflow-y-auto rf-overflow-x-hidden rf-flex rf-flex-col"
       >
         <DialogHeader>

--- a/lib/components/ImportComponentDialog2/components/TscircuitPackageDetailsDialog.tsx
+++ b/lib/components/ImportComponentDialog2/components/TscircuitPackageDetailsDialog.tsx
@@ -56,7 +56,7 @@ export const TscircuitPackageDetailsDialog = ({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         showOverlay={false}
-        style={{ width: "calc(100vw - 2rem)" }}
+        style={{ width: "calc(100vw - 2rem)", zIndex: 102 }}
         className="rf-max-w-5xl no-scrollbar !rf-overflow-y-auto rf-max-h-[90vh] rf-overflow-hidden rf-flex rf-flex-col rf-rounded-sm"
       >
         <DialogHeader className="rf-pb-4 rf-border-b">

--- a/lib/components/ImportComponentDialog2/components/TscircuitPackageDetailsDialog.tsx
+++ b/lib/components/ImportComponentDialog2/components/TscircuitPackageDetailsDialog.tsx
@@ -14,6 +14,7 @@ import type {
   TscircuitPackageSearchResult,
 } from "../types"
 import type { Package } from "@tscircuit/fake-snippets/schema"
+import { zIndexMap } from "lib/utils/z-index-map"
 
 interface TscircuitPackageDetailsDialogProps {
   packageResult: TscircuitPackageSearchResult | null
@@ -56,7 +57,7 @@ export const TscircuitPackageDetailsDialog = ({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         showOverlay={false}
-        style={{ width: "calc(100vw - 2rem)", zIndex: 102 }}
+        style={{ width: "calc(100vw - 2rem)", zIndex: zIndexMap.dialogAbove }}
         className="rf-max-w-5xl no-scrollbar !rf-overflow-y-auto rf-max-h-[90vh] rf-overflow-hidden rf-flex rf-flex-col rf-rounded-sm"
       >
         <DialogHeader className="rf-pb-4 rf-border-b">

--- a/lib/components/ImportComponentDialog2/components/TscircuitPackageDetailsDialog.tsx
+++ b/lib/components/ImportComponentDialog2/components/TscircuitPackageDetailsDialog.tsx
@@ -57,7 +57,10 @@ export const TscircuitPackageDetailsDialog = ({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         showOverlay={false}
-        style={{ width: "calc(100vw - 2rem)", zIndex: zIndexMap.dialogAbove }}
+        style={{
+          width: "calc(100vw - 2rem)",
+          zIndex: zIndexMap.importComponentDetailsDialog,
+        }}
         className="rf-max-w-5xl no-scrollbar !rf-overflow-y-auto rf-max-h-[90vh] rf-overflow-hidden rf-flex rf-flex-col rf-rounded-sm"
       >
         <DialogHeader className="rf-pb-4 rf-border-b">

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -1,5 +1,6 @@
 export const zIndexMap = {
   dialog: 101,
+  dialogAbove: 102,
 } as const
 
 export type ZIndexKey = keyof typeof zIndexMap

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -1,6 +1,6 @@
 export const zIndexMap = {
-  dialog: 101,
-  dialogAbove: 102,
+  importComponentDialog: 101,
+  importComponentDetailsDialog: 102,
 } as const
 
 export type ZIndexKey = keyof typeof zIndexMap


### PR DESCRIPTION
Before: 


https://github.com/user-attachments/assets/c62607db-251a-49fc-8e4e-20bc59c0fcf5


After:

https://github.com/user-attachments/assets/e6f8c768-94f4-4acb-acbc-94b7799f0678

Fixes the Import Component package details view so clicking “See Details” no longer appears broken when the details dialog opens behind the search dialog.

The issue was caused by the search dialog using a higher z-index than the package details dialog, which left the details dialog mounted but hidden in the visual stack. This change raises the details dialog z-index above the search dialog.
