### PR TITLE
chore: update easyeda to latest release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/runframe",
@@ -53,7 +52,7 @@
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
         "debug": "^4.4.0",
-        "easyeda": "^0.0.256",
+        "easyeda": "^0.0.266",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -945,7 +944,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.256", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-+tAJepTalUhj0A8uCH0ERqI9LQAychghMzNntd3v4hatxwzYP8zHuqIVDit32N5nKgW3TSP2UQ+EDbxeEemtPQ=="],
+    "easyeda": ["easyeda@0.0.266", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-pT4PA09jLdVVSL46QaV/aGfcRTGFgEtxIc7axmVzxt4YiavZbhVxyuqGfb1OV3FeMh0TofJqyjPESAxGMPDwNQ=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
     "debug": "^4.4.0",
-    "easyeda": "^0.0.256",
+    "easyeda": "^0.0.266",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
### Motivation
- Bump `easyeda` to the latest published release to pick up fixes and keep dependency resolution current.

### Description
- Update `easyeda` in `package.json` from `^0.0.256` to `^0.0.266` and refresh `bun.lock` so the workspace resolves `easyeda@0.0.266`.
- No AGENTS skill was used because this change is a straightforward dependency bump performed with the package manager (`bun add`).

### Testing
- Ran `npm view easyeda version` to verify the latest published version (`0.0.266`) and it succeeded.
- Ran `bun run format:check` which completed successfully with "No fixes applied".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69efacf3a8dc832796b97516201c176f)