### PR TITLE
chore: bump circuit-json-to-lbrn to ^0.0.74

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/runframe",
@@ -43,7 +42,7 @@
         "circuit-json-to-bom-csv": "^0.0.8",
         "circuit-json-to-gerber": "^0.0.49",
         "circuit-json-to-kicad": "^0.0.120",
-        "circuit-json-to-lbrn": "^0.0.71",
+        "circuit-json-to-lbrn": "^0.0.74",
         "circuit-json-to-pnp-csv": "^0.0.7",
         "circuit-json-to-step": "^0.0.18",
         "class-variance-authority": "^0.7.1",
@@ -847,7 +846,7 @@
 
     "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.120", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-FQ3w6UqWLaQw2LRYSbWPC+79adsB/E2IxLXyaPw0mFFRYaGxshVBM7vHDLZRG1E8p1rza64fWCE8Uy/lkff7Zw=="],
 
-    "circuit-json-to-lbrn": ["circuit-json-to-lbrn@0.0.71", "", { "dependencies": { "lbrnts": "^0.0.18", "manifold-3d": "^3.3.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Wv2JAN+ewXBiH2HDibEQEXVEgUOWDp3yRquFb6Yea2jJcXcfzAH9GsBOqYKMoHJnYQbjVxL2sl6cV8TQqD++Hg=="],
+    "circuit-json-to-lbrn": ["circuit-json-to-lbrn@0.0.74", "", { "dependencies": { "lbrnts": "^0.0.18", "manifold-3d": "^3.3.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-MVdlgj+TYHrTdcE2IN7yk6rkULJ02owAr9zeZg9UeypfrdjNNAjBvhz3Ue24FDGjSmvQdmjiafbUKAOapslxZQ=="],
 
     "circuit-json-to-pnp-csv": ["circuit-json-to-pnp-csv@0.0.7", "", { "dependencies": { "papaparse": "^5.4.1" }, "peerDependencies": { "@tscircuit/soup-util": "*", "typescript": "^5.0.0" } }, "sha512-WAdNRHtaPhQM8X5NN/43WMBKDCEKQSLShg/mHIZxMUzJviymnfbq6rJj/2WvDqm/bogey34PyTEHwF3mC7zxlQ=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "circuit-json-to-bom-csv": "^0.0.8",
     "circuit-json-to-gerber": "^0.0.49",
     "circuit-json-to-kicad": "^0.0.120",
-    "circuit-json-to-lbrn": "^0.0.71",
+    "circuit-json-to-lbrn": "^0.0.74",
     "circuit-json-to-pnp-csv": "^0.0.7",
     "circuit-json-to-step": "^0.0.18",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
### Motivation
- Bring `circuit-json-to-lbrn` up to the latest published release to pick up bug fixes and dependency updates.

### Description
- Update `circuit-json-to-lbrn` from `^0.0.71` to `^0.0.74` in `package.json`.
- Refresh `bun.lock` to pin the resolved `circuit-json-to-lbrn@0.0.74` entry and update the lockfile metadata.
- No runtime source code changes were made.

### Testing
- No automated test suite was executed for this dependency-only change.
- Local verification was performed by running `npm view circuit-json-to-lbrn version` and installing via `bun add -d circuit-json-to-lbrn@latest`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1438a91988327b06aa7218943b628)