### PR TITLE
Harden AI review rendering and iframe messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ RunFrame can be embedded in an iframe, allowing you to evaluate tscircuit code f
 
     <script>
       const iframe = document.getElementById("runframe")
+      const iframeOrigin = new URL(iframe.src).origin
 
       // Listen for ready message from iframe
       window.addEventListener("message", (event) => {
+        if (event.source !== iframe.contentWindow) return
+        if (event.origin !== iframeOrigin) return
+
         if (event.data?.runframe_type === "runframe_ready_to_receive") {
           // Send circuit configuration
           iframe.contentWindow.postMessage(
@@ -130,7 +134,7 @@ RunFrame can be embedded in an iframe, allowing you to evaluate tscircuit code f
                 entrypoint: "main.tsx",
               },
             },
-            "*"
+            iframeOrigin
           )
         }
       })
@@ -143,6 +147,9 @@ RunFrame can be embedded in an iframe, allowing you to evaluate tscircuit code f
 
 ```tsx
 window.addEventListener("message", (event) => {
+  if (event.source !== iframe.contentWindow) return
+  if (event.origin !== iframeOrigin) return
+
   if (event.data?.runframe_type === "runframe_event") {
     const { type } = event.data.runframe_event
     if (type === "error") {

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@tscircuit/eval": "^0.0.838",
         "@tscircuit/solver-utils": "^0.0.7",
+        "dompurify": "^3.3.1",
       },
       "devDependencies": {
         "@babel/standalone": "^7.26.10",

--- a/lib/components/AiReviewDialog/ViewAiReviewView.tsx
+++ b/lib/components/AiReviewDialog/ViewAiReviewView.tsx
@@ -1,9 +1,10 @@
+import DOMPurify from "dompurify"
+import { getRegistryKy } from "lib/utils/get-registry-ky"
+import { marked } from "marked"
 import { useEffect, useMemo, useState } from "react"
 import { Button } from "../ui/button"
 import { DialogHeader, DialogTitle } from "../ui/dialog"
-import { marked } from "marked"
 import type { AiReview } from "./types"
-import { getRegistryKy } from "lib/utils/get-registry-ky"
 
 export const AiReviewViewView = ({
   review,
@@ -49,10 +50,10 @@ export const AiReviewViewView = ({
     return () => clearTimeout(timeout)
   }, [aiReviewId])
 
-  const html = useMemo(
-    () => marked.parse(review.ai_review_text || "") as string,
-    [review.ai_review_text],
-  )
+  const html = useMemo(() => {
+    const dirtyHtml = marked.parse(aiReviewText || "") as string
+    return DOMPurify.sanitize(dirtyHtml)
+  }, [aiReviewText])
   return (
     <>
       <DialogHeader className="rf-flex rf-flex-row rf-items-center rf-justify-between">
@@ -62,10 +63,10 @@ export const AiReviewViewView = ({
         <DialogTitle>AI Review</DialogTitle>
       </DialogHeader>
       {aiReviewText ? (
-        <div
-          className="rf-h-64 rf-overflow-y-auto rf-prose rf-max-w-none rf-mt-2"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
+        <div className="rf-h-64 rf-overflow-y-auto rf-prose rf-max-w-none rf-mt-2">
+          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Markdown HTML is sanitized with DOMPurify before rendering. */}
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        </div>
       ) : (
         <div className="rf-h-64 rf-overflow-y-auto rf-prose rf-max-w-none rf-mt-2">
           <div className="rf-flex rf-items-center rf-justify-center rf-h-full">

--- a/lib/components/RunFrameWithIframe/RunFrameWithIframe.tsx
+++ b/lib/components/RunFrameWithIframe/RunFrameWithIframe.tsx
@@ -9,28 +9,63 @@ export interface RunFrameWithIframeProps extends RunFrameProps {
   iframeUrl?: string
 }
 
+export const getRunFrameIframeTargetOrigin = (
+  iframeUrl: string,
+  baseUrl: string,
+) => {
+  const origin = new URL(iframeUrl, baseUrl).origin
+
+  return origin === "null" ? "*" : origin
+}
+
+export const isRunFrameReadyMessageFromIframe = (
+  event: Pick<MessageEvent, "data" | "origin" | "source">,
+  iframeWindow: Window | null,
+  targetOrigin: string,
+) => {
+  if (!iframeWindow || event.source !== iframeWindow) return false
+  if (targetOrigin !== "*" && event.origin !== targetOrigin) return false
+
+  return event.data?.runframe_type === "runframe_ready_to_receive"
+}
+
 export const RunFrameWithIframe = ({
   iframeUrl = "https://runframe.tscircuit.com/iframe.html",
   ...runFrameProps
 }: RunFrameWithIframeProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const runFramePropsRef = useRef(runFrameProps)
+  runFramePropsRef.current = runFrameProps
 
   useEffect(() => {
+    const targetOrigin = getRunFrameIframeTargetOrigin(
+      iframeUrl,
+      window.location.href,
+    )
+
     const handleMessage = (event: MessageEvent) => {
-      if (event.data?.runframe_type === "runframe_ready_to_receive") {
-        iframeRef.current?.contentWindow?.postMessage(
-          {
-            runframe_type: "runframe_props_changed",
-            runframe_props: runFrameProps,
-          },
-          "*",
-        )
+      const iframeWindow = iframeRef.current?.contentWindow ?? null
+
+      if (!iframeWindow) return
+
+      if (
+        !isRunFrameReadyMessageFromIframe(event, iframeWindow, targetOrigin)
+      ) {
+        return
       }
+
+      iframeWindow.postMessage(
+        {
+          runframe_type: "runframe_props_changed",
+          runframe_props: runFramePropsRef.current,
+        },
+        targetOrigin,
+      )
     }
 
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)
-  }, [])
+  }, [iframeUrl])
 
   return (
     <div>

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "dependencies": {
     "@tscircuit/eval": "^0.0.838",
-    "@tscircuit/solver-utils": "^0.0.7"
+    "@tscircuit/solver-utils": "^0.0.7",
+    "dompurify": "^3.3.1"
   }
 }

--- a/tests/runframe-iframe-message-security.test.ts
+++ b/tests/runframe-iframe-message-security.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import {
+  getRunFrameIframeTargetOrigin,
+  isRunFrameReadyMessageFromIframe,
+} from "../lib/components/RunFrameWithIframe/RunFrameWithIframe"
+
+test("getRunFrameIframeTargetOrigin resolves absolute and relative iframe urls", () => {
+  expect(
+    getRunFrameIframeTargetOrigin(
+      "https://runframe.tscircuit.com/iframe.html",
+      "https://example.com/embed",
+    ),
+  ).toBe("https://runframe.tscircuit.com")
+
+  expect(
+    getRunFrameIframeTargetOrigin("/iframe.html", "https://example.com/embed"),
+  ).toBe("https://example.com")
+})
+
+test("getRunFrameIframeTargetOrigin falls back for opaque iframe origins", () => {
+  expect(
+    getRunFrameIframeTargetOrigin("about:blank", "https://example.com/embed"),
+  ).toBe("*")
+})
+
+test("isRunFrameReadyMessageFromIframe rejects unexpected sources and origins", () => {
+  const iframeWindow = {} as Window
+  const otherWindow = {} as Window
+  const targetOrigin = "https://runframe.tscircuit.com"
+
+  expect(
+    isRunFrameReadyMessageFromIframe(
+      {
+        data: { runframe_type: "runframe_ready_to_receive" },
+        origin: targetOrigin,
+        source: iframeWindow,
+      },
+      iframeWindow,
+      targetOrigin,
+    ),
+  ).toBe(true)
+
+  expect(
+    isRunFrameReadyMessageFromIframe(
+      {
+        data: { runframe_type: "runframe_ready_to_receive" },
+        origin: targetOrigin,
+        source: otherWindow,
+      },
+      iframeWindow,
+      targetOrigin,
+    ),
+  ).toBe(false)
+
+  expect(
+    isRunFrameReadyMessageFromIframe(
+      {
+        data: { runframe_type: "runframe_ready_to_receive" },
+        origin: "https://attacker.example",
+        source: iframeWindow,
+      },
+      iframeWindow,
+      targetOrigin,
+    ),
+  ).toBe(false)
+})


### PR DESCRIPTION
## Summary
- sanitize AI review Markdown with DOMPurify before rendering
- verify iframe ready messages against the embedded iframe window and expected origin
- send runframe props to the iframe origin instead of `*`
- update iframe embed docs and add regression coverage

Fixes #3376

## Checks
- `npx --yes bun test tests/runframe-iframe-message-security.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib/components/RunFrameWithIframe/RunFrameWithIframe.tsx tests/runframe-iframe-message-security.test.ts`
- `npx --yes bun x biome format README.md lib/components/AiReviewDialog/ViewAiReviewView.tsx lib/components/RunFrameWithIframe/RunFrameWithIframe.tsx tests/runframe-iframe-message-security.test.ts`

Notes:
- `npx --yes bun test` currently crashes in Bun 1.3.13 during `tests/circuitwebworker2.test.tsx` before reaching this change.
- `npx --yes bun run format:check` reports repo-wide CRLF formatting drift in existing files.