### PR TITLE
Track the activity to calculate DAU/WAU/MAU of runframe and circuit json preview usage

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -46,6 +46,7 @@ import { RenderLogViewer } from "../RenderLogViewer/RenderLogViewer"
 import { SolversTabContent } from "../SolversTabContent/SolversTabContent"
 import { capitalizeFirstLetters } from "lib/utils"
 import { useErrorTelemetry } from "lib/hooks/use-error-telemetry"
+import { usePostHogActivity } from "lib/hooks/use-posthog-activity"
 import type {
   PreviewContentProps,
   TabId,
@@ -126,6 +127,12 @@ export const CircuitJsonPreview = ({
   onPcbBoundsSelected,
 }: PreviewContentProps) => {
   useStyles()
+  usePostHogActivity({
+    source: "circuit_json_viewer",
+    component: "CircuitJsonPreview",
+    isWebEmbedded,
+    defaultActiveTab: defaultActiveTab ?? defaultTab,
+  })
 
   const {
     versions: evalVersions,

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -127,12 +127,6 @@ export const CircuitJsonPreview = ({
   onPcbBoundsSelected,
 }: PreviewContentProps) => {
   useStyles()
-  usePostHogActivity({
-    source: "circuit_json_viewer",
-    component: "CircuitJsonPreview",
-    isWebEmbedded,
-    defaultActiveTab: defaultActiveTab ?? defaultTab,
-  })
 
   const {
     versions: evalVersions,
@@ -178,6 +172,12 @@ export const CircuitJsonPreview = ({
     defaultActiveTab ?? fallbackTab,
     defaultActiveTab,
   )
+  usePostHogActivity({
+    source: "runframe",
+    component: "CircuitJsonPreview",
+    isWebEmbedded,
+    activeTab,
+  })
   const [lastActiveTab, setLastActiveTab] = useState<TabId | null>(null)
   const [isFullScreen, setIsFullScreen] = useState(defaultToFullScreen)
 

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -43,6 +43,7 @@ import { FileMenuLeftHeader } from "../FileMenuLeftHeader"
 import { LoadingSkeleton } from "../ui/LoadingSkeleton"
 import { useStyles } from "../../hooks/use-styles"
 import { useCircuitJsonFile } from "../../hooks/use-circuit-json-file"
+import { usePostHogActivity } from "../../hooks/use-posthog-activity"
 import { API_BASE } from "../RunFrameWithApi/api-base"
 import {
   buildRunCompletedPayload,
@@ -95,6 +96,13 @@ export type { RunFrameProps }
 
 export const RunFrame = (props: RunFrameProps) => {
   useStyles()
+  usePostHogActivity({
+    source: "runframe",
+    sessionToken: props.tscircuitSessionToken,
+    component: "RunFrame",
+    isWebEmbedded: props.isWebEmbedded,
+    defaultActiveTab: props.defaultActiveTab ?? props.defaultTab,
+  })
 
   const circuitJson = useRunFrameStore((s) => s.circuitJson)
   const setCircuitJson = useRunFrameStore((s) => s.setCircuitJson)

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -96,13 +96,6 @@ export type { RunFrameProps }
 
 export const RunFrame = (props: RunFrameProps) => {
   useStyles()
-  usePostHogActivity({
-    source: "runframe",
-    sessionToken: props.tscircuitSessionToken,
-    component: "RunFrame",
-    isWebEmbedded: props.isWebEmbedded,
-    defaultActiveTab: props.defaultActiveTab ?? props.defaultTab,
-  })
 
   const circuitJson = useRunFrameStore((s) => s.circuitJson)
   const setCircuitJson = useRunFrameStore((s) => s.setCircuitJson)
@@ -216,6 +209,12 @@ export const RunFrame = (props: RunFrameProps) => {
   const [activeTab, setActiveTab] = useState<TabId>(
     props.defaultActiveTab ?? props.defaultTab ?? "pcb",
   )
+  usePostHogActivity({
+    source: "runframe",
+    component: "RunFrame",
+    isWebEmbedded: props.isWebEmbedded,
+    activeTab,
+  })
   useEffect(() => {
     if (props.debug) Debug.enable("run-frame*")
   }, [props.debug])

--- a/lib/hooks/use-posthog-activity.ts
+++ b/lib/hooks/use-posthog-activity.ts
@@ -13,9 +13,8 @@ export const usePostHogActivity = (properties: RunFrameActivityProperties) => {
     }
   }, [
     properties.source,
-    properties.sessionToken,
     properties.component,
     properties.isWebEmbedded,
-    properties.defaultActiveTab,
+    properties.activeTab,
   ])
 }

--- a/lib/hooks/use-posthog-activity.ts
+++ b/lib/hooks/use-posthog-activity.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react"
+import {
+  captureRunFrameActivity,
+  type RunFrameActivityProperties,
+} from "lib/utils/posthog"
+
+export const usePostHogActivity = (properties: RunFrameActivityProperties) => {
+  useEffect(() => {
+    try {
+      captureRunFrameActivity(properties)
+    } catch {
+      // Analytics should never affect rendering.
+    }
+  }, [
+    properties.source,
+    properties.sessionToken,
+    properties.component,
+    properties.isWebEmbedded,
+    properties.defaultActiveTab,
+  ])
+}

--- a/lib/utils/posthog.ts
+++ b/lib/utils/posthog.ts
@@ -56,34 +56,6 @@ export const getRunFrameAnonymousId = () => {
   }
 }
 
-const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
-  const payload = token.split(".")[1]
-  if (!payload) return null
-
-  try {
-    const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/")
-    const paddedPayload = normalizedPayload.padEnd(
-      Math.ceil(normalizedPayload.length / 4) * 4,
-      "=",
-    )
-    return JSON.parse(atob(paddedPayload))
-  } catch {
-    return null
-  }
-}
-
-export const getAccountIdFromSessionToken = (sessionToken?: string | null) => {
-  if (!sessionToken) return null
-
-  const payload = decodeJwtPayload(sessionToken)
-  const accountId = payload?.account_id ?? payload?.accountId
-
-  if (typeof accountId !== "string") return null
-  if (!accountId.trim()) return null
-
-  return accountId
-}
-
 const shouldTrackOnLocalhost = () =>
   getWindowVar("TSCIRCUIT_USE_RUNFRAME_FOR_CLI") === true
 
@@ -104,30 +76,25 @@ export const initPostHog = () => {
 
 export interface RunFrameActivityProperties {
   source: "runframe" | "circuit_json_viewer"
-  sessionToken?: string | null
   component?: string
   isWebEmbedded?: boolean
-  defaultActiveTab?: string
+  activeTab?: string
 }
 
-const getRunFrameIdentity = (sessionToken?: string | null) => {
+const getRunFrameIdentity = () => {
   if (!initPostHog()) return null
 
-  const accountId = getAccountIdFromSessionToken(sessionToken)
   const embedDomain = getRunFrameEmbedDomain()
   const shouldUseDomainIdentity =
     embedDomain != null && !isLocalHost(embedDomain)
   let anonymousId = null
-  if (!accountId && !shouldUseDomainIdentity) {
+  if (!shouldUseDomainIdentity) {
     anonymousId = getRunFrameAnonymousId()
   }
   let distinctId: string | undefined
-  let identityType: "account_id" | "domain" | "anonymous_id"
+  let identityType: "domain" | "anonymous_id"
 
-  if (accountId) {
-    distinctId = `account:${accountId}`
-    identityType = "account_id"
-  } else if (shouldUseDomainIdentity) {
+  if (shouldUseDomainIdentity) {
     distinctId = `domain:${embedDomain}`
     identityType = "domain"
   } else {
@@ -139,7 +106,6 @@ const getRunFrameIdentity = (sessionToken?: string | null) => {
   }
 
   return {
-    accountId,
     embedDomain,
     anonymousId,
     distinctId,
@@ -149,19 +115,15 @@ const getRunFrameIdentity = (sessionToken?: string | null) => {
 
 export const captureRunFrameTelemetry = (
   eventName: string,
-  { source, sessionToken, ...properties }: RunFrameActivityProperties,
+  { source, ...properties }: RunFrameActivityProperties,
 ) => {
-  const identity = getRunFrameIdentity(sessionToken)
+  const identity = getRunFrameIdentity()
   if (!identity) return
 
-  const { accountId, embedDomain, anonymousId, distinctId, identityType } =
-    identity
+  const { embedDomain, anonymousId, distinctId, identityType } = identity
 
   if (distinctId) {
     const personProperties: Record<string, string> = {}
-    if (accountId) {
-      personProperties.account_id = accountId
-    }
     if (identityType === "domain" && embedDomain) {
       personProperties.embed_domain = embedDomain
     }
@@ -175,7 +137,6 @@ export const captureRunFrameTelemetry = (
   posthog.capture(eventName, {
     ...properties,
     source,
-    account_id: accountId,
     embed_domain: embedDomain,
     runframe_anonymous_id: anonymousId,
     identity_type: identityType,

--- a/lib/utils/posthog.ts
+++ b/lib/utils/posthog.ts
@@ -1,15 +1,193 @@
 import posthog from "posthog-js"
 
-if (
-  !window.location.hostname.includes("localhost") &&
-  !window.location.hostname.includes("127.0.0.1")
-) {
-  if (!(posthog as any).__loaded) {
-    posthog.init("phc_htd8AQjSfVEsFCLQMAiUooG4Q0DKBCjqYuQglc9V3Wo", {
-      api_host: "https://postpig.tscircuit.com",
-      person_profiles: "always",
-    })
+import { getWindowVar } from "./get-registry-ky"
+
+const POSTHOG_PROJECT_API_KEY =
+  "phc_htd8AQjSfVEsFCLQMAiUooG4Q0DKBCjqYuQglc9V3Wo"
+const POSTHOG_API_HOST = "https://postpig.tscircuit.com"
+const RUNFRAME_ANONYMOUS_ID_STORAGE_KEY = "runframe:anonymous-id"
+
+const isBrowser = () => typeof window !== "undefined"
+
+const isLocalHost = (hostname: string) =>
+  hostname.includes("localhost") || hostname.includes("127.0.0.1")
+
+const getHostnameFromUrl = (url: string) => {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return null
   }
 }
+
+export const getRunFrameEmbedDomain = () => {
+  if (!isBrowser()) return null
+
+  let referrerHostname = null
+  if (document.referrer) {
+    referrerHostname = getHostnameFromUrl(document.referrer)
+  }
+
+  return referrerHostname ?? window.location.hostname
+}
+
+const createRunFrameAnonymousId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+export const getRunFrameAnonymousId = () => {
+  if (!isBrowser()) return null
+
+  try {
+    const storedId = window.localStorage.getItem(
+      RUNFRAME_ANONYMOUS_ID_STORAGE_KEY,
+    )
+    if (storedId) return storedId
+
+    const newId = createRunFrameAnonymousId()
+    window.localStorage.setItem(RUNFRAME_ANONYMOUS_ID_STORAGE_KEY, newId)
+    return newId
+  } catch {
+    return null
+  }
+}
+
+const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
+  const payload = token.split(".")[1]
+  if (!payload) return null
+
+  try {
+    const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/")
+    const paddedPayload = normalizedPayload.padEnd(
+      Math.ceil(normalizedPayload.length / 4) * 4,
+      "=",
+    )
+    return JSON.parse(atob(paddedPayload))
+  } catch {
+    return null
+  }
+}
+
+export const getAccountIdFromSessionToken = (sessionToken?: string | null) => {
+  if (!sessionToken) return null
+
+  const payload = decodeJwtPayload(sessionToken)
+  const accountId = payload?.account_id ?? payload?.accountId
+
+  if (typeof accountId !== "string") return null
+  if (!accountId.trim()) return null
+
+  return accountId
+}
+
+const shouldTrackOnLocalhost = () =>
+  getWindowVar("TSCIRCUIT_USE_RUNFRAME_FOR_CLI") === true
+
+export const initPostHog = () => {
+  if (!isBrowser()) return false
+  if (isLocalHost(window.location.hostname) && !shouldTrackOnLocalhost()) {
+    return false
+  }
+  if ((posthog as any).__loaded) return true
+
+  posthog.init(POSTHOG_PROJECT_API_KEY, {
+    api_host: POSTHOG_API_HOST,
+    person_profiles: "always",
+  })
+
+  return true
+}
+
+export interface RunFrameActivityProperties {
+  source: "runframe" | "circuit_json_viewer"
+  sessionToken?: string | null
+  component?: string
+  isWebEmbedded?: boolean
+  defaultActiveTab?: string
+}
+
+const getRunFrameIdentity = (sessionToken?: string | null) => {
+  if (!initPostHog()) return null
+
+  const accountId = getAccountIdFromSessionToken(sessionToken)
+  const embedDomain = getRunFrameEmbedDomain()
+  const shouldUseDomainIdentity =
+    embedDomain != null && !isLocalHost(embedDomain)
+  let anonymousId = null
+  if (!accountId && !shouldUseDomainIdentity) {
+    anonymousId = getRunFrameAnonymousId()
+  }
+  let distinctId: string | undefined
+  let identityType: "account_id" | "domain" | "anonymous_id"
+
+  if (accountId) {
+    distinctId = `account:${accountId}`
+    identityType = "account_id"
+  } else if (shouldUseDomainIdentity) {
+    distinctId = `domain:${embedDomain}`
+    identityType = "domain"
+  } else {
+    distinctId = undefined
+    if (anonymousId) {
+      distinctId = `anonymous:${anonymousId}`
+    }
+    identityType = "anonymous_id"
+  }
+
+  return {
+    accountId,
+    embedDomain,
+    anonymousId,
+    distinctId,
+    identityType,
+  }
+}
+
+export const captureRunFrameTelemetry = (
+  eventName: string,
+  { source, sessionToken, ...properties }: RunFrameActivityProperties,
+) => {
+  const identity = getRunFrameIdentity(sessionToken)
+  if (!identity) return
+
+  const { accountId, embedDomain, anonymousId, distinctId, identityType } =
+    identity
+
+  if (distinctId) {
+    const personProperties: Record<string, string> = {}
+    if (accountId) {
+      personProperties.account_id = accountId
+    }
+    if (identityType === "domain" && embedDomain) {
+      personProperties.embed_domain = embedDomain
+    }
+    if (identityType === "anonymous_id" && anonymousId) {
+      personProperties.runframe_anonymous_id = anonymousId
+    }
+
+    posthog.identify(distinctId, personProperties)
+  }
+
+  posthog.capture(eventName, {
+    ...properties,
+    source,
+    account_id: accountId,
+    embed_domain: embedDomain,
+    runframe_anonymous_id: anonymousId,
+    identity_type: identityType,
+  })
+}
+
+export const captureRunFrameActivity = (
+  properties: RunFrameActivityProperties,
+) => {
+  captureRunFrameTelemetry("runframe_activity", properties)
+}
+
+initPostHog()
 
 export { posthog }


### PR DESCRIPTION
Distinct id's creation pattern
- domain:<embed_domain> for non-local embedded usage without token
- anonymous:<localStorage id> for CLI/local tsci dev usage not logged in