### PR TITLE
Wire runtime platform config into RunFrame

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -167,7 +167,7 @@ export const RunFrame = (props: RunFrameProps) => {
                 props.projectBaseUrl || `${API_BASE}/files/static`,
             },
             ...(props.platformConfig && {
-              platformConfig: props.platformConfig,
+              platform: props.platformConfig as any,
             }),
             verbose: true,
             ...(props.enableFetchProxy && {
@@ -326,7 +326,7 @@ export const RunFrame = (props: RunFrameProps) => {
             projectBaseUrl: props.projectBaseUrl || `${API_BASE}/files/static`,
           },
           ...(props.platformConfig && {
-            platformConfig: props.platformConfig,
+            platform: props.platformConfig as any,
           }),
           ...(props.enableFetchProxy && {
             enableFetchProxy: props.enableFetchProxy,

--- a/lib/components/RunFrameForCli/RunFrameForCli.tsx
+++ b/lib/components/RunFrameForCli/RunFrameForCli.tsx
@@ -1,3 +1,4 @@
+import type { PlatformConfig } from "@tscircuit/props"
 import { useLocalStorageState } from "lib/hooks/use-local-storage-state"
 import { useCallback, useState } from "react"
 import { RunFrameWithApi } from "../RunFrameWithApi/RunFrameWithApi"
@@ -9,6 +10,8 @@ export const RunFrameForCli = (props: {
   scenarioSelectorContent?: React.ReactNode
   workerBlobUrl?: string
   enableFetchProxy?: boolean
+  platformConfig?: PlatformConfig
+  loadPlatformConfig?: () => Promise<PlatformConfig | null | undefined>
 }) => {
   const [shouldLoadLatestEval, setLoadLatestEval] = useLocalStorageState(
     "load-latest-eval",
@@ -46,6 +49,8 @@ export const RunFrameForCli = (props: {
         showFilesSwitch
         showFileMenu={false}
         enableFetchProxy={props.enableFetchProxy}
+        platformConfig={props.platformConfig}
+        loadPlatformConfig={props.loadPlatformConfig}
         initialMainComponentPath={initialMainComponentPath}
         onLoginRequired={openLoginDialog}
         onMainComponentPathChange={updateMainComponentHash}

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -1,5 +1,5 @@
 import { applyEditEventsToManualEditsFile } from "@tscircuit/core"
-import type { ManualEditsFile } from "@tscircuit/props"
+import type { ManualEditsFile, PlatformConfig } from "@tscircuit/props"
 import Debug from "debug"
 import { useEditEventController } from "lib/hooks/use-edit-event-controller"
 import { useHasReceivedInitialFilesLoaded } from "lib/hooks/use-has-received-initial-files-loaded"
@@ -103,6 +103,17 @@ export interface RunFrameWithApiProps {
   fileFilter?: (filename: string) => boolean
 
   /**
+   * Platform config passed to the eval worker.
+   */
+  platformConfig?: PlatformConfig
+
+  /**
+   * Async loader for platform config. Useful for CLI/dev-server integrations
+   * that need to keep function-valued config on the server.
+   */
+  loadPlatformConfig?: () => Promise<PlatformConfig | null | undefined>
+
+  /**
    * Called when an action requires authentication (e.g. reporting autorouting bugs)
    */
   onLoginRequired?: () => void
@@ -125,13 +136,59 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
   const fsMap = useRunFrameStore((s) => s.fsMap)
   const recentlySavedFiles = useRunFrameStore((s) => s.recentlySavedFiles)
   const allFiles = useMemo(() => Array.from(fsMap.keys()), [fsMap])
+  const [loadedPlatformConfig, setLoadedPlatformConfig] = useState<
+    PlatformConfig | undefined
+  >(undefined)
+  const [isLoadingPlatformConfig, setIsLoadingPlatformConfig] = useState(
+    Boolean(props.loadPlatformConfig),
+  )
+  const [platformConfigError, setPlatformConfigError] = useState<Error | null>(
+    null,
+  )
+  const platformConfig = loadedPlatformConfig ?? props.platformConfig
+
+  useEffect(() => {
+    if (!props.loadPlatformConfig) {
+      setLoadedPlatformConfig(undefined)
+      setIsLoadingPlatformConfig(false)
+      setPlatformConfigError(null)
+      return
+    }
+
+    let cancelled = false
+    setIsLoadingPlatformConfig(true)
+    setPlatformConfigError(null)
+    props
+      .loadPlatformConfig()
+      .then((config) => {
+        if (cancelled) return
+        setLoadedPlatformConfig(config ?? undefined)
+      })
+      .catch((error) => {
+        if (cancelled) return
+        setPlatformConfigError(
+          error instanceof Error ? error : new Error(String(error)),
+        )
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingPlatformConfig(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [props.loadPlatformConfig])
+
   const projectConfigContent = useMemo(() => {
     const rawConfig = fsMap.get("tscircuit.config.json")
     return typeof rawConfig === "string" ? rawConfig : undefined
   }, [fsMap])
   const boardFiles = useMemo(
-    () => getBoardFilesFromConfig(allFiles, projectConfigContent),
-    [allFiles, projectConfigContent],
+    () =>
+      getBoardFilesFromConfig(allFiles, projectConfigContent, {
+        includeBoardFiles: platformConfig?.includeBoardFiles,
+      }),
+    [allFiles, projectConfigContent, platformConfig?.includeBoardFiles],
   )
   const circuitJson = useRunFrameStore((s) => s.circuitJson)
 
@@ -290,6 +347,22 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
     [pushEvent],
   )
 
+  if (isLoadingPlatformConfig) {
+    return (
+      <div className="rf-flex rf-min-h-screen rf-items-center rf-justify-center rf-text-sm rf-text-slate-600">
+        Loading runtime config...
+      </div>
+    )
+  }
+
+  if (platformConfigError) {
+    return (
+      <div className="rf-flex rf-min-h-screen rf-items-center rf-justify-center rf-p-6 rf-text-sm rf-text-red-700">
+        Failed to load runtime config: {platformConfigError.message}
+      </div>
+    )
+  }
+
   return (
     <RunFrame
       fsMap={fsMap}
@@ -335,6 +408,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
         markRenderComplete()
       }}
       onRunCompleted={handleRunCompleted}
+      platformConfig={platformConfig}
       editEvents={editEventsForRender}
       onEditEvent={(ee) => {
         pushEditEvent(ee)

--- a/lib/components/RunFrameWithApi/load-platform-config-from-api.ts
+++ b/lib/components/RunFrameWithApi/load-platform-config-from-api.ts
@@ -1,0 +1,182 @@
+import type { PlatformConfig } from "@tscircuit/props"
+
+const FUNCTION_REF_KEY = "__tscircuitDevServerRpcFunction"
+const BINARY_REF_KEY = "__tscircuitDevServerRpcBinary"
+const RESPONSE_REF_KEY = "__tscircuitDevServerRpcResponse"
+const REQUEST_REF_KEY = "__tscircuitDevServerRpcRequest"
+const HEADERS_REF_KEY = "__tscircuitDevServerRpcHeaders"
+
+const isRecord = (value: unknown): value is Record<string, any> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const arrayBufferToBase64 = (value: ArrayBufferLike | ArrayBufferView) => {
+  const bytes = ArrayBuffer.isView(value)
+    ? new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+    : new Uint8Array(value)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+const base64ToArrayBuffer = (value: string) => {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes.buffer
+}
+
+const headersToEntries = (headers: Headers): [string, string][] => {
+  const entries: [string, string][] = []
+  headers.forEach((value, key) => entries.push([key, value]))
+  return entries
+}
+
+const encodeRpcValue = async (value: unknown): Promise<unknown> => {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value ?? null
+  }
+
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    return {
+      [BINARY_REF_KEY]: true,
+      base64: arrayBufferToBase64(value),
+    }
+  }
+
+  if (value instanceof Headers) {
+    return {
+      [HEADERS_REF_KEY]: true,
+      entries: headersToEntries(value),
+    }
+  }
+
+  if (value instanceof Request) {
+    const requestBody =
+      value.method === "GET" || value.method === "HEAD"
+        ? undefined
+        : await value.clone().arrayBuffer()
+    return {
+      [REQUEST_REF_KEY]: true,
+      url: value.url,
+      method: value.method,
+      headers: headersToEntries(value.headers),
+      body: requestBody
+        ? {
+            [BINARY_REF_KEY]: true,
+            base64: arrayBufferToBase64(requestBody),
+          }
+        : undefined,
+    }
+  }
+
+  if (value instanceof Response) {
+    return {
+      [RESPONSE_REF_KEY]: true,
+      status: value.status,
+      statusText: value.statusText,
+      headers: headersToEntries(value.headers),
+      body: {
+        [BINARY_REF_KEY]: true,
+        base64: arrayBufferToBase64(await value.clone().arrayBuffer()),
+      },
+    }
+  }
+
+  if (Array.isArray(value)) return Promise.all(value.map(encodeRpcValue))
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      await Promise.all(
+        Object.entries(value).map(async ([key, item]) => [
+          key,
+          await encodeRpcValue(item),
+        ]),
+      ),
+    )
+  }
+
+  return value
+}
+
+const decodeRpcValue = (value: unknown, rpcUrl: string): any => {
+  if (Array.isArray(value))
+    return value.map((item) => decodeRpcValue(item, rpcUrl))
+  if (!isRecord(value)) return value
+
+  if (value[FUNCTION_REF_KEY]) {
+    const target = value.target
+    return async (...args: unknown[]) => {
+      const response = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          target,
+          args: await Promise.all(args.map(encodeRpcValue)),
+        }),
+      })
+
+      const payload = await response.json()
+      if (!response.ok) {
+        throw new Error(
+          payload?.message ?? "Failed to call runtime platformConfig function",
+        )
+      }
+
+      return decodeRpcValue(payload.result, rpcUrl)
+    }
+  }
+
+  if (value[BINARY_REF_KEY]) return base64ToArrayBuffer(String(value.base64))
+
+  if (value[HEADERS_REF_KEY]) {
+    return new Headers(value.entries as [string, string][])
+  }
+
+  if (value[REQUEST_REF_KEY]) {
+    return new Request(String(value.url), {
+      method: String(value.method),
+      headers: value.headers as [string, string][],
+      body: value.body ? decodeRpcValue(value.body, rpcUrl) : undefined,
+    })
+  }
+
+  if (value[RESPONSE_REF_KEY]) {
+    return new Response(
+      value.body ? decodeRpcValue(value.body, rpcUrl) : undefined,
+      {
+        status: Number(value.status),
+        statusText: String(value.statusText ?? ""),
+        headers: value.headers as [string, string][],
+      },
+    )
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      decodeRpcValue(item, rpcUrl),
+    ]),
+  )
+}
+
+export const loadPlatformConfigFromApi = async (
+  runtimeConfigApiUrl = "/api/dev/runtime-config",
+): Promise<PlatformConfig | undefined> => {
+  const response = await fetch(runtimeConfigApiUrl)
+  const payload = await response.json()
+
+  if (!response.ok) {
+    throw new Error(payload?.message ?? "Failed to load runtime config")
+  }
+
+  if (!payload.platformConfig) return undefined
+
+  const rpcUrl = `${runtimeConfigApiUrl.replace(/\/$/, "")}/rpc`
+  return decodeRpcValue(payload.platformConfig, rpcUrl) as PlatformConfig
+}

--- a/lib/components/RunFrameWithApi/standalone.tsx
+++ b/lib/components/RunFrameWithApi/standalone.tsx
@@ -6,6 +6,7 @@ import { RunFrameStaticBuildViewer } from "../RunFrameStaticBuildViewer/RunFrame
 import type { CircuitJsonFileReference } from "../RunFrameStaticBuildViewer/RunFrameStaticBuildViewer"
 import type { ComponentProps } from "react"
 import type { TabId } from "../CircuitJsonPreview/PreviewContentProps"
+import { loadPlatformConfigFromApi } from "./load-platform-config-from-api"
 
 declare global {
   interface Window {
@@ -13,6 +14,7 @@ declare global {
     TSCIRCUIT_RUNFRAME_STATIC_FILE_LIST?: CircuitJsonFileReference[]
     TSCIRCUIT_DEFAULT_MAIN_COMPONENT_PATH?: string
     TSCIRCUIT_PACKAGE_NAME?: string
+    TSCIRCUIT_RUNTIME_CONFIG_API_URL?: string
   }
 }
 
@@ -94,6 +96,13 @@ const runframeStandaloneProps: ComponentProps<typeof RunFrameWithApi> = {
   const staticFileList = window.TSCIRCUIT_RUNFRAME_STATIC_FILE_LIST
   const defaultMainComponentPath = window.TSCIRCUIT_DEFAULT_MAIN_COMPONENT_PATH
   const projectName = window.TSCIRCUIT_PACKAGE_NAME
+  const runtimeConfigApiUrl = window.TSCIRCUIT_RUNTIME_CONFIG_API_URL
+  const propsWithRuntimeConfig = {
+    ...runframeStandaloneProps,
+    ...(runtimeConfigApiUrl && {
+      loadPlatformConfig: () => loadPlatformConfigFromApi(runtimeConfigApiUrl),
+    }),
+  }
   if (Array.isArray(staticFileList)) {
     const tabSelected = parseTabFromHash()
     root.render(
@@ -105,13 +114,13 @@ const runframeStandaloneProps: ComponentProps<typeof RunFrameWithApi> = {
       />,
     )
   } else if (window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI) {
-    root.render(<RunFrameForCli {...runframeStandaloneProps} />)
+    root.render(<RunFrameForCli {...propsWithRuntimeConfig} />)
   } else {
     const { fsMap } = await loadScriptsAsFsMap()
     if (fsMap.size > 0) {
       root.render(<RunFrame {...runframeStandaloneProps} fsMap={fsMap} />)
     } else {
-      root.render(<RunFrameWithApi {...runframeStandaloneProps} />)
+      root.render(<RunFrameWithApi {...propsWithRuntimeConfig} />)
     }
   }
 })()

--- a/lib/utils/get-board-files-from-config.ts
+++ b/lib/utils/get-board-files-from-config.ts
@@ -26,9 +26,14 @@ const parseProjectConfig = (configContent?: string): ProjectConfig | null => {
 export const getBoardFilesFromConfig = (
   files: string[],
   configContent?: string,
+  options: {
+    includeBoardFiles?: string[]
+  } = {},
 ): string[] => {
   const parsedConfig = parseProjectConfig(configContent)
-  const includeBoardFiles = parsedConfig?.includeBoardFiles?.filter(Boolean)
+  const includeBoardFiles =
+    options.includeBoardFiles?.filter(Boolean) ??
+    parsedConfig?.includeBoardFiles?.filter(Boolean)
 
   if (includeBoardFiles && includeBoardFiles.length > 0) {
     const matchers = includeBoardFiles.map(

--- a/tests/get-board-files-from-config.test.ts
+++ b/tests/get-board-files-from-config.test.ts
@@ -22,6 +22,24 @@ describe("getBoardFilesFromConfig", () => {
     ])
   })
 
+  test("prefers runtime includeBoardFiles over synced json config", () => {
+    const files = [
+      "json-config/main.board.tsx",
+      "runtime-config/main.board.tsx",
+      "src/fallback.tsx",
+    ]
+
+    const config = stringifyConfig({
+      includeBoardFiles: ["json-config/**/*.board.tsx"],
+    })
+
+    expect(
+      getBoardFilesFromConfig(files, config, {
+        includeBoardFiles: ["runtime-config/**/*.board.tsx"],
+      }),
+    ).toEqual(["runtime-config/main.board.tsx"])
+  })
+
   test("falls back to default file extensions when config is missing", () => {
     const files = [
       "src/board.tsx",

--- a/tests/load-platform-config-from-api.test.ts
+++ b/tests/load-platform-config-from-api.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, test } from "bun:test"
+import { loadPlatformConfigFromApi } from "../lib/components/RunFrameWithApi/load-platform-config-from-api"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test("loadPlatformConfigFromApi decodes RPC-backed platform config functions", async () => {
+  const requests: Array<{ url: string; body?: any }> = []
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input.toString()
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    requests.push({ url, body })
+
+    if (url === "/api/dev/runtime-config") {
+      return new Response(
+        JSON.stringify({
+          platformConfig: {
+            includeBoardFiles: ["boards/**/*.board.tsx"],
+            footprintLibraryMap: {
+              ti: {
+                __tscircuitDevServerRpcFunction: true,
+                target: {
+                  type: "path",
+                  path: ["footprintLibraryMap", "ti"],
+                },
+              },
+            },
+          },
+        }),
+      )
+    }
+
+    if (url === "/api/dev/runtime-config/rpc") {
+      return new Response(
+        JSON.stringify({
+          result: {
+            footprintCircuitJson: [
+              { type: "source_component", name: body.args[0] },
+            ],
+          },
+        }),
+      )
+    }
+
+    return new Response("not found", { status: 404 })
+  }) as typeof fetch
+
+  const platformConfig = await loadPlatformConfigFromApi(
+    "/api/dev/runtime-config",
+  )
+  const tiLoader = platformConfig?.footprintLibraryMap?.ti as (
+    partName: string,
+  ) => Promise<{ footprintCircuitJson: any[] }>
+
+  expect(platformConfig?.includeBoardFiles).toEqual(["boards/**/*.board.tsx"])
+  expect(typeof tiLoader).toBe("function")
+  await expect(tiLoader("MSP430")).resolves.toEqual({
+    footprintCircuitJson: [{ type: "source_component", name: "MSP430" }],
+  })
+  expect(requests[1]).toEqual({
+    url: "/api/dev/runtime-config/rpc",
+    body: {
+      target: {
+        type: "path",
+        path: ["footprintLibraryMap", "ti"],
+      },
+      args: ["MSP430"],
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Wires runtime platform config into the CLI RunFrame path so dev preview can consume the CLI server's safe runtime config bridge.

## What changed

- Adds a browser-side runtime config loader that reconstructs RPC-backed platform config functions.
- Surfaces `platformConfig` and `loadPlatformConfig` through `RunFrameWithApi` and `RunFrameForCli`.
- Uses runtime `includeBoardFiles` when selecting board files, instead of only synced `tscircuit.config.json`.
- Passes platform config to `@tscircuit/eval` using the expected `platform` key.
- Hooks the standalone CLI bootstrap into `window.TSCIRCUIT_RUNTIME_CONFIG_API_URL`.

## Validation

- `bun test tests/load-platform-config-from-api.test.ts tests/get-board-files-from-config.test.ts`

## Notes

- Repo-wide `bunx tsc --noEmit --pretty false` is currently blocked by existing duplicate `CircuitJson` type drift and KiCad export typings unrelated to this patch.
