### PR TITLE
add circuit-to-svg as a dev dep

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.20",
         "chokidar-cli": "^3.0.0",
+        "circuit-to-svg": "^0.0.356",
         "circuit-json-to-bom-csv": "^0.0.9",
         "circuit-json-to-gerber": "^0.0.78",
         "circuit-json-to-kicad": "^0.0.153",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.20",
     "chokidar-cli": "^3.0.0",
+    "circuit-to-svg": "^0.0.356",
     "circuit-json-to-bom-csv": "^0.0.9",
     "circuit-json-to-gerber": "^0.0.78",
     "circuit-json-to-kicad": "^0.0.153",


### PR DESCRIPTION
Adds circuit-to-svg@^0.0.356 directly to runframe so the prebuilt standalone preview bundle used
  by tsci dev embeds the current SVG renderer instead of resolving an older transitive copy at
  publish time.