### PR TITLE
fix: harden ai review html and iframe messaging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
         "debug": "^4.4.0",
+        "dompurify": "^3.4.11",
         "easyeda": "^0.0.269",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",

--- a/lib/components/AiReviewDialog/ViewAiReviewView.tsx
+++ b/lib/components/AiReviewDialog/ViewAiReviewView.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react"
 import { Button } from "../ui/button"
 import { DialogHeader, DialogTitle } from "../ui/dialog"
-import { marked } from "marked"
 import type { AiReview } from "./types"
 import { getRegistryKy } from "lib/utils/get-registry-ky"
+import { renderAiReviewMarkdown } from "./render-ai-review-markdown"
 
 export const AiReviewViewView = ({
   review,
@@ -50,8 +50,8 @@ export const AiReviewViewView = ({
   }, [aiReviewId])
 
   const html = useMemo(
-    () => marked.parse(review.ai_review_text || "") as string,
-    [review.ai_review_text],
+    () => renderAiReviewMarkdown(aiReviewText ?? ""),
+    [aiReviewText],
   )
   return (
     <>

--- a/lib/components/AiReviewDialog/render-ai-review-markdown.ts
+++ b/lib/components/AiReviewDialog/render-ai-review-markdown.ts
@@ -1,0 +1,24 @@
+import createDOMPurify from "dompurify"
+import { marked } from "marked"
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+
+export const renderAiReviewMarkdown = (markdown: string): string => {
+  const html = marked.parse(markdown || "") as string
+  const purifier =
+    typeof window === "undefined" ? undefined : createDOMPurify(window)
+
+  if (purifier?.isSupported && typeof purifier.sanitize === "function") {
+    return purifier.sanitize(html, {
+      USE_PROFILES: { html: true },
+    })
+  }
+
+  return escapeHtml(html)
+}

--- a/lib/components/RunFrameWithIframe/RunFrameWithIframe.tsx
+++ b/lib/components/RunFrameWithIframe/RunFrameWithIframe.tsx
@@ -9,28 +9,73 @@ export interface RunFrameWithIframeProps extends RunFrameProps {
   iframeUrl?: string
 }
 
+export const getIframeTargetOrigin = (
+  iframeUrl: string,
+  baseUrl?: string,
+): string | null => {
+  try {
+    return new URL(
+      iframeUrl,
+      baseUrl ??
+        (typeof window === "undefined" ? undefined : window.location.href),
+    ).origin
+  } catch {
+    return null
+  }
+}
+
+export const shouldSendRunFramePropsToIframe = ({
+  event,
+  iframeWindow,
+  targetOrigin,
+}: {
+  event: MessageEvent
+  iframeWindow: WindowProxy | null | undefined
+  targetOrigin: string | null
+}): boolean => {
+  return (
+    Boolean(iframeWindow) &&
+    Boolean(targetOrigin) &&
+    event.source === iframeWindow &&
+    event.origin === targetOrigin &&
+    event.data?.runframe_type === "runframe_ready_to_receive"
+  )
+}
+
 export const RunFrameWithIframe = ({
   iframeUrl = "https://runframe.tscircuit.com/iframe.html",
   ...runFrameProps
 }: RunFrameWithIframeProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const runFramePropsRef = useRef(runFrameProps)
 
   useEffect(() => {
+    runFramePropsRef.current = runFrameProps
+  }, [runFrameProps])
+
+  useEffect(() => {
+    const targetOrigin = getIframeTargetOrigin(iframeUrl)
     const handleMessage = (event: MessageEvent) => {
-      if (event.data?.runframe_type === "runframe_ready_to_receive") {
+      if (
+        shouldSendRunFramePropsToIframe({
+          event,
+          iframeWindow: iframeRef.current?.contentWindow,
+          targetOrigin,
+        })
+      ) {
         iframeRef.current?.contentWindow?.postMessage(
           {
             runframe_type: "runframe_props_changed",
-            runframe_props: runFrameProps,
+            runframe_props: runFramePropsRef.current,
           },
-          "*",
+          targetOrigin!,
         )
       }
     }
 
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)
-  }, [])
+  }, [iframeUrl])
 
   return (
     <div>

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
     "debug": "^4.4.0",
+    "dompurify": "^3.4.11",
     "easyeda": "^0.0.269",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",

--- a/tests/ai-review-markdown-sanitization.test.ts
+++ b/tests/ai-review-markdown-sanitization.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { renderAiReviewMarkdown } from "../lib/components/AiReviewDialog/render-ai-review-markdown"
+
+test("AI review markdown renderer does not emit raw script tags without a DOM sanitizer", () => {
+  const html = renderAiReviewMarkdown(
+    '# Review\n\n<img src=x onerror="alert(1)"><script>alert(1)</script>',
+  )
+
+  expect(html).not.toContain("<script")
+  expect(html).not.toContain("<img")
+  expect(html).toContain("&lt;")
+})

--- a/tests/runframe-iframe-message-security.test.ts
+++ b/tests/runframe-iframe-message-security.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import {
+  getIframeTargetOrigin,
+  shouldSendRunFramePropsToIframe,
+} from "../lib/components/RunFrameWithIframe/RunFrameWithIframe"
+
+const createMessageEvent = (overrides: Partial<MessageEvent>): MessageEvent =>
+  ({
+    data: { runframe_type: "runframe_ready_to_receive" },
+    origin: "https://runframe.tscircuit.com",
+    source: {} as WindowProxy,
+    ...overrides,
+  }) as MessageEvent
+
+test("iframe postMessage guard requires expected source and origin", () => {
+  const iframeWindow = {} as WindowProxy
+  const targetOrigin = "https://runframe.tscircuit.com"
+
+  expect(
+    shouldSendRunFramePropsToIframe({
+      event: createMessageEvent({ source: iframeWindow }),
+      iframeWindow,
+      targetOrigin,
+    }),
+  ).toBe(true)
+
+  expect(
+    shouldSendRunFramePropsToIframe({
+      event: createMessageEvent({ source: {} as WindowProxy }),
+      iframeWindow,
+      targetOrigin,
+    }),
+  ).toBe(false)
+
+  expect(
+    shouldSendRunFramePropsToIframe({
+      event: createMessageEvent({
+        origin: "https://attacker.example",
+        source: iframeWindow,
+      }),
+      iframeWindow,
+      targetOrigin,
+    }),
+  ).toBe(false)
+
+  expect(
+    shouldSendRunFramePropsToIframe({
+      event: createMessageEvent({
+        data: { runframe_type: "not_ready" },
+        source: iframeWindow,
+      }),
+      iframeWindow,
+      targetOrigin,
+    }),
+  ).toBe(false)
+})
+
+test("iframe target origin is derived from absolute and relative iframe URLs", () => {
+  expect(
+    getIframeTargetOrigin("https://runframe.tscircuit.com/iframe.html"),
+  ).toBe("https://runframe.tscircuit.com")
+  expect(
+    getIframeTargetOrigin("/iframe.html", "https://app.example/view"),
+  ).toBe("https://app.example")
+  expect(getIframeTargetOrigin("http://[::1", "https://app.example/view")).toBe(
+    null,
+  )
+})


### PR DESCRIPTION
Fixes #3376

## Summary
- Sanitize AI review markdown HTML with DOMPurify before rendering it via `dangerouslySetInnerHTML`.
- Use the latest loaded AI review text when rendering the review body.
- Restrict iframe `postMessage` handling to the expected iframe `contentWindow` and derived iframe origin, and send responses to that origin instead of `*`.
- Add tests for markdown fallback safety and iframe message source/origin guards.

## Verification
- `bun test tests\ai-review-markdown-sanitization.test.ts tests\runframe-iframe-message-security.test.ts`
- `bun x tsc --noEmit`
- `bun x biome format lib\components\AiReviewDialog\ViewAiReviewView.tsx lib\components\AiReviewDialog\render-ai-review-markdown.ts lib\components\RunFrameWithIframe\RunFrameWithIframe.tsx tests\ai-review-markdown-sanitization.test.ts tests\runframe-iframe-message-security.test.ts package.json bun.lock`
- `bun run build:lib`
- `git diff --check`

Note: I also attempted full `bun test`; Bun 1.3.14 crashed with an internal panic while running the existing `circuitwebworker2` test after the new security tests had passed.