### PR TITLE
fix(runframe): treat .cjs as a dynamic (source) file, not a static asset

### DIFF
--- a/lib/components/RunFrameWithApi/isDynamicFilePath.ts
+++ b/lib/components/RunFrameWithApi/isDynamicFilePath.ts
@@ -4,6 +4,7 @@ export const DYNAMIC_FILE_EXTENSIONS = [
   ".jsx",
   ".js",
   ".mjs",
+  ".cjs",
   ".json",
   ".kicad_pcb",
   ".kicad_sch",

--- a/tests/runframe-dynamic-file-path.test.ts
+++ b/tests/runframe-dynamic-file-path.test.ts
@@ -9,6 +9,12 @@ describe("isDynamicFilePath", () => {
     )
   })
 
+  test("treats executable CommonJS (.cjs) files as dynamic content", () => {
+    expect(isDynamicFilePath("node_modules/jscad-planner/dist/index.cjs")).toBe(
+      true,
+    )
+  })
+
   test("keeps static model assets as static assets", () => {
     expect(isDynamicFilePath("models/connector.step")).toBe(false)
     expect(isDynamicFilePath("models/board.glb")).toBe(false)


### PR DESCRIPTION
## Problem

The store decides which uploaded files get their real text content vs. a `"__STATIC_ASSET__"` placeholder via `isDynamicFilePath`. Its `DYNAMIC_FILE_EXTENSIONS` lists `.tsx/.ts/.jsx/.js/.mjs/.json` (+ kicad) but **omits `.cjs`**. So a `.cjs` source file is treated as binary: its content is replaced with `"__STATIC_ASSET__"`, and when eval then imports it as code the worker throws `ReferenceError: __STATIC_ASSET__ is not defined`.

This is the runframe-side twin of tscircuit/eval#2996 (which lets eval *transpile* `.cjs`); both are needed for `.cjs` deps to work in `tsci dev`. `tsci build` (Node) is unaffected — this only manifests in the browser/dev path.

## Fix

Add `".cjs"` to `DYNAMIC_FILE_EXTENSIONS` (next to `.mjs`), so runframe delivers its real source instead of a placeholder.

## Test

Extends `tests/runframe-dynamic-file-path.test.ts` with a `.cjs` case.

## Risk

Negligible — `.cjs` is source, not a binary asset; it belongs in the list.

---

Draft: opening for review before merge. (`package.json` is intentionally excluded — local yalc artifacts only.)