### PR TITLE
fix(runframe): use the embedded eval worker in CLI standalone mode

### DIFF
--- a/lib/components/RunFrameWithApi/standalone.tsx
+++ b/lib/components/RunFrameWithApi/standalone.tsx
@@ -105,7 +105,17 @@ const runframeStandaloneProps: ComponentProps<typeof RunFrameWithApi> = {
       />,
     )
   } else if (window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI) {
-    root.render(<RunFrameForCli {...runframeStandaloneProps} />)
+    // RunFrameForCli reads the embedded eval worker from `workerBlobUrl`, while the
+    // standalone build injects it as `evalWebWorkerBlobUrl` — map it explicitly so
+    // the embedded worker is used instead of forcing a CDN eval fetch.
+    // Props are forwarded by name (not spread), so any new standalone prop that
+    // RunFrameForCli should receive must be added here.
+    root.render(
+      <RunFrameForCli
+        workerBlobUrl={runframeStandaloneProps.evalWebWorkerBlobUrl}
+        enableFetchProxy={runframeStandaloneProps.enableFetchProxy}
+      />,
+    )
   } else {
     const { fsMap } = await loadScriptsAsFsMap()
     if (fsMap.size > 0) {


### PR DESCRIPTION
## Problem

The CLI branch in `standalone.tsx` rendered `<RunFrameForCli {...runframeStandaloneProps} />`. `runframeStandaloneProps` carries the embedded eval-worker blob under **`evalWebWorkerBlobUrl`**, but `RunFrameForCli` reads **`workerBlobUrl`** — a different name — so the blob was silently dropped. `RunFrameForCli` then computes:

```ts
forceLatestEvalVersion={!props.workerBlobUrl && shouldLoadLatestEval}  // -> true
```

and **fetches eval from the CDN** instead of using the embedded worker.

Whenever an eval worker is embedded into the standalone (the tscircuit umbrella build fills that placeholder), CLI mode ignored it and silently downloaded a *different* eval from the network. This breaks **offline / air-gapped / pinned-eval / locally-built-eval** usage of `tsci dev` — the embedded worker should be authoritative.

## Fix

Forward the blob explicitly under the name `RunFrameForCli` actually reads, and pass `enableFetchProxy`:

```tsx
root.render(
  <RunFrameForCli
    workerBlobUrl={runframeStandaloneProps.evalWebWorkerBlobUrl}
    enableFetchProxy={runframeStandaloneProps.enableFetchProxy}
  />,
)
```

Forwarding by name (rather than spreading `runframeStandaloneProps`, typed as `ComponentProps<typeof RunFrameWithApi>`) also avoids passing `RunFrameForCli` an `evalWebWorkerBlobUrl` prop it does not accept. A comment documents that new standalone props must be added here explicitly.

## Risk

Low, no regression for normal users: when no worker is embedded, `evalWebWorkerBlobUrl` is `undefined`, so behavior is unchanged and it still loads the latest eval from the CDN. Behavior only changes when a worker blob is actually embedded — the case this is meant to handle.

---

Draft: opening for review before merge. (`package.json` is intentionally excluded — local yalc artifacts only.)
