### PR TITLE
fix static runframe file hash selection

### DIFF
--- a/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
+++ b/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
@@ -36,7 +36,14 @@ export const RunFrameStaticBuildViewer = (
 
   const [currentCircuitJsonPath, setCurrentCircuitJsonPath] = useState<string>(
     () => {
-      return props.initialCircuitPath ?? ""
+      if (typeof window === "undefined") return props.initialCircuitPath ?? ""
+      const params = new URLSearchParams(window.location.hash.slice(1))
+      return (
+        params.get("file") ??
+        params.get("main_component") ??
+        props.initialCircuitPath ??
+        ""
+      )
     },
   )
 
@@ -69,10 +76,31 @@ export const RunFrameStaticBuildViewer = (
     [],
   )
 
+  const updateFileHash = useCallback((filePath: string) => {
+    if (typeof window === "undefined") return
+    const params = new URLSearchParams(window.location.hash.slice(1))
+    if (
+      params.get("file") === filePath &&
+      (!params.has("main_component") ||
+        params.get("main_component") === filePath)
+    ) {
+      return
+    }
+    params.set("file", filePath)
+    if (params.has("main_component")) {
+      params.set("main_component", filePath)
+    }
+    const newHash = params.toString() ? `#${params.toString()}` : ""
+    if (newHash === window.location.hash) return
+    const newUrl = `${window.location.pathname}${window.location.search}${newHash}`
+    window.history.replaceState(null, "", newUrl)
+  }, [])
+
   const loadCircuitJsonFile = useCallback(
     async (filePath: string) => {
       if (fileCache[filePath]) {
         setCircuitJson(fileCache[filePath])
+        updateFileHash(filePath)
         props.onCircuitJsonPathChange?.(filePath)
         return
       }
@@ -102,6 +130,7 @@ export const RunFrameStaticBuildViewer = (
 
         setFileCache((prev) => ({ ...prev, [filePath]: circuitJsonData }))
         setCircuitJson(circuitJsonData)
+        updateFileHash(filePath)
         props.onCircuitJsonPathChange?.(filePath)
 
         setFailedFiles((prev) => {
@@ -130,6 +159,7 @@ export const RunFrameStaticBuildViewer = (
       props.onFetchFile,
       props.onCircuitJsonPathChange,
       defaultFetchFile,
+      updateFileHash,
     ],
   )
 

--- a/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
+++ b/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
@@ -7,6 +7,7 @@ import { FileMenuLeftHeader } from "../FileMenuLeftHeader"
 import { guessEntrypoint } from "lib/runner"
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary"
 import type { TabId } from "../CircuitJsonPreview/PreviewContentProps"
+import { useStaticCircuitJsonPathHash } from "./use-static-circuit-json-path-hash"
 
 export interface CircuitJsonFileReference {
   filePath: string
@@ -34,18 +35,8 @@ export const RunFrameStaticBuildViewer = (
 ) => {
   useStyles()
 
-  const [currentCircuitJsonPath, setCurrentCircuitJsonPath] = useState<string>(
-    () => {
-      if (typeof window === "undefined") return props.initialCircuitPath ?? ""
-      const params = new URLSearchParams(window.location.hash.slice(1))
-      return (
-        params.get("file") ??
-        params.get("main_component") ??
-        props.initialCircuitPath ??
-        ""
-      )
-    },
-  )
+  const { currentCircuitJsonPath, setCurrentCircuitJsonPath, updateFileHash } =
+    useStaticCircuitJsonPathHash(props.initialCircuitPath)
 
   const [circuitJson, setCircuitJson] = useState<CircuitJson | null>(null)
   const [isLoadingCurrentFile, setIsLoadingCurrentFile] = useState(false)
@@ -75,26 +66,6 @@ export const RunFrameStaticBuildViewer = (
     },
     [],
   )
-
-  const updateFileHash = useCallback((filePath: string) => {
-    if (typeof window === "undefined") return
-    const params = new URLSearchParams(window.location.hash.slice(1))
-    if (
-      params.get("file") === filePath &&
-      (!params.has("main_component") ||
-        params.get("main_component") === filePath)
-    ) {
-      return
-    }
-    params.set("file", filePath)
-    if (params.has("main_component")) {
-      params.set("main_component", filePath)
-    }
-    const newHash = params.toString() ? `#${params.toString()}` : ""
-    if (newHash === window.location.hash) return
-    const newUrl = `${window.location.pathname}${window.location.search}${newHash}`
-    window.history.replaceState(null, "", newUrl)
-  }, [])
 
   const loadCircuitJsonFile = useCallback(
     async (filePath: string) => {

--- a/lib/components/RunFrameStaticBuildViewer/use-static-circuit-json-path-hash.ts
+++ b/lib/components/RunFrameStaticBuildViewer/use-static-circuit-json-path-hash.ts
@@ -1,0 +1,72 @@
+import { useCallback, useState } from "react"
+
+export const getInitialCircuitJsonPath = ({
+  hash,
+  initialCircuitPath,
+}: {
+  hash: string
+  initialCircuitPath?: string
+}) => {
+  const params = new URLSearchParams(
+    hash.startsWith("#") ? hash.slice(1) : hash,
+  )
+  return (
+    params.get("file") ??
+    params.get("main_component") ??
+    initialCircuitPath ??
+    ""
+  )
+}
+
+export const getUpdatedCircuitJsonPathHash = ({
+  hash,
+  filePath,
+}: {
+  hash: string
+  filePath: string
+}) => {
+  const params = new URLSearchParams(
+    hash.startsWith("#") ? hash.slice(1) : hash,
+  )
+  if (
+    params.get("file") === filePath &&
+    (!params.has("main_component") || params.get("main_component") === filePath)
+  ) {
+    return hash.startsWith("#") ? hash : hash ? `#${hash}` : ""
+  }
+  params.set("file", filePath)
+  if (params.has("main_component")) {
+    params.set("main_component", filePath)
+  }
+  const nextHash = params.toString()
+  return nextHash ? `#${nextHash}` : ""
+}
+
+export const useStaticCircuitJsonPathHash = (initialCircuitPath?: string) => {
+  const [currentCircuitJsonPath, setCurrentCircuitJsonPath] = useState<string>(
+    () => {
+      if (typeof window === "undefined") return initialCircuitPath ?? ""
+      return getInitialCircuitJsonPath({
+        hash: window.location.hash,
+        initialCircuitPath,
+      })
+    },
+  )
+
+  const updateFileHash = useCallback((filePath: string) => {
+    if (typeof window === "undefined") return
+    const newHash = getUpdatedCircuitJsonPathHash({
+      hash: window.location.hash,
+      filePath,
+    })
+    if (newHash === window.location.hash) return
+    const newUrl = `${window.location.pathname}${window.location.search}${newHash}`
+    window.history.replaceState(null, "", newUrl)
+  }, [])
+
+  return {
+    currentCircuitJsonPath,
+    setCurrentCircuitJsonPath,
+    updateFileHash,
+  }
+}

--- a/tests/runframe-static-build-viewer-hash.test.ts
+++ b/tests/runframe-static-build-viewer-hash.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import {
+  getInitialCircuitJsonPath,
+  getUpdatedCircuitJsonPathHash,
+} from "../lib/components/RunFrameStaticBuildViewer/use-static-circuit-json-path-hash"
+
+test("RunFrameStaticBuildViewer reads file from hash", () => {
+  expect(
+    getInitialCircuitJsonPath({
+      hash: "#file=index.circuit.tsx&main_component=TEST.circuit.tsx",
+    }),
+  ).toBe("index.circuit.tsx")
+})
+
+test("RunFrameStaticBuildViewer falls back to main_component from hash", () => {
+  expect(
+    getInitialCircuitJsonPath({
+      hash: "#main_component=index.circuit.tsx",
+    }),
+  ).toBe("index.circuit.tsx")
+})
+
+test("RunFrameStaticBuildViewer updates file hash", () => {
+  expect(
+    getUpdatedCircuitJsonPathHash({
+      hash: "#tab=schematic&file=TEST.circuit.tsx",
+      filePath: "index.circuit.tsx",
+    }),
+  ).toBe("#tab=schematic&file=index.circuit.tsx")
+})


### PR DESCRIPTION
**Motivation**: 

RunFrameStaticBuildViewer ignored #file/#main_component URL params, so static deployments selected the wrong circuit even though the same URL worked in local CLI.

**Fix**

Fixes static runframe file selection by making RunFrameStaticBuildViewer read #file / #main_component from the URL, matching the behavior that already works in the local CLI. It also updates #file when the selected static circuit changes.