### PR TITLE
Fix static viewer file URL selection

### DIFF
--- a/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
+++ b/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
@@ -7,6 +7,10 @@ import { FileMenuLeftHeader } from "../FileMenuLeftHeader"
 import { guessEntrypoint } from "lib/runner"
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary"
 import type { TabId } from "../CircuitJsonPreview/PreviewContentProps"
+import {
+  getUpdatedHashForFileSelection,
+  getUrlSelectedFileFromLocation,
+} from "./url-selection"
 
 export interface CircuitJsonFileReference {
   filePath: string
@@ -31,36 +35,18 @@ const getErrorMessage = (error: unknown) =>
 
 const getUrlSelectedFile = (): string | null => {
   if (typeof window === "undefined") return null
-
-  const searchParams = new URLSearchParams(window.location.search)
-  const hashParams = new URLSearchParams(window.location.hash.slice(1))
-
-  // Treat the hash as canonical for in-app navigation once it exists.
-  return (
-    hashParams.get("file") ??
-    hashParams.get("main_component") ??
-    searchParams.get("file") ??
-    searchParams.get("main_component")
+  return getUrlSelectedFileFromLocation(
+    window.location.search,
+    window.location.hash,
   )
 }
 
 const updateFileHash = (filePath: string) => {
   if (typeof window === "undefined") return
 
-  const params = new URLSearchParams(window.location.hash.slice(1))
-  if (
-    params.get("file") === filePath &&
-    (!params.has("main_component") || params.get("main_component") === filePath)
-  ) {
-    return
-  }
-
-  params.set("file", filePath)
-  if (params.has("main_component")) {
-    params.set("main_component", filePath)
-  }
-  const newHash = params.toString()
-  const newUrl = `${window.location.pathname}${window.location.search}${newHash.length > 0 ? `#${newHash}` : ""}`
+  const newHash = getUpdatedHashForFileSelection(window.location.hash, filePath)
+  if (newHash === null) return
+  const newUrl = `${window.location.pathname}${window.location.search}${newHash}`
   window.history.replaceState(null, "", newUrl)
 }
 

--- a/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
+++ b/lib/components/RunFrameStaticBuildViewer/RunFrameStaticBuildViewer.tsx
@@ -29,6 +29,41 @@ export interface RunFrameStaticBuildViewerProps {
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : "An unknown error occurred"
 
+const getUrlSelectedFile = (): string | null => {
+  if (typeof window === "undefined") return null
+
+  const searchParams = new URLSearchParams(window.location.search)
+  const hashParams = new URLSearchParams(window.location.hash.slice(1))
+
+  // Treat the hash as canonical for in-app navigation once it exists.
+  return (
+    hashParams.get("file") ??
+    hashParams.get("main_component") ??
+    searchParams.get("file") ??
+    searchParams.get("main_component")
+  )
+}
+
+const updateFileHash = (filePath: string) => {
+  if (typeof window === "undefined") return
+
+  const params = new URLSearchParams(window.location.hash.slice(1))
+  if (
+    params.get("file") === filePath &&
+    (!params.has("main_component") || params.get("main_component") === filePath)
+  ) {
+    return
+  }
+
+  params.set("file", filePath)
+  if (params.has("main_component")) {
+    params.set("main_component", filePath)
+  }
+  const newHash = params.toString()
+  const newUrl = `${window.location.pathname}${window.location.search}${newHash.length > 0 ? `#${newHash}` : ""}`
+  window.history.replaceState(null, "", newUrl)
+}
+
 export const RunFrameStaticBuildViewer = (
   props: RunFrameStaticBuildViewerProps,
 ) => {
@@ -36,7 +71,7 @@ export const RunFrameStaticBuildViewer = (
 
   const [currentCircuitJsonPath, setCurrentCircuitJsonPath] = useState<string>(
     () => {
-      return props.initialCircuitPath ?? ""
+      return getUrlSelectedFile() ?? props.initialCircuitPath ?? ""
     },
   )
 
@@ -146,7 +181,26 @@ export const RunFrameStaticBuildViewer = (
     if (selectedPath && availableFiles.includes(selectedPath)) {
       loadCircuitJsonFile(selectedPath)
     }
+  }, [availableFiles, currentCircuitJsonPath, loadCircuitJsonFile])
+
+  useEffect(() => {
+    if (!currentCircuitJsonPath) return
+    updateFileHash(currentCircuitJsonPath)
   }, [currentCircuitJsonPath])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const handleHashChange = () => {
+      const nextPath = getUrlSelectedFile()
+      if (!nextPath || nextPath === currentCircuitJsonPath) return
+      if (!availableFiles.includes(nextPath)) return
+      setCurrentCircuitJsonPath(nextPath)
+    }
+
+    window.addEventListener("hashchange", handleHashChange)
+    return () => window.removeEventListener("hashchange", handleHashChange)
+  }, [availableFiles, currentCircuitJsonPath])
 
   const handleFileChange = useCallback((newPath: string) => {
     setCurrentCircuitJsonPath(newPath)

--- a/lib/components/RunFrameStaticBuildViewer/url-selection.ts
+++ b/lib/components/RunFrameStaticBuildViewer/url-selection.ts
@@ -1,0 +1,36 @@
+export const getUrlSelectedFileFromLocation = (
+  search: string,
+  hash: string,
+): string | null => {
+  const searchParams = new URLSearchParams(search)
+  const hashParams = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash)
+
+  return (
+    hashParams.get("file") ??
+    hashParams.get("main_component") ??
+    searchParams.get("file") ??
+    searchParams.get("main_component")
+  )
+}
+
+export const getUpdatedHashForFileSelection = (
+  hash: string,
+  filePath: string,
+): string | null => {
+  const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash)
+
+  if (
+    params.get("file") === filePath &&
+    (!params.has("main_component") || params.get("main_component") === filePath)
+  ) {
+    return null
+  }
+
+  params.set("file", filePath)
+  if (params.has("main_component")) {
+    params.set("main_component", filePath)
+  }
+
+  const newHash = params.toString()
+  return newHash.length > 0 ? `#${newHash}` : ""
+}

--- a/lib/components/RunFrameStaticBuildViewer/url-selection.ts
+++ b/lib/components/RunFrameStaticBuildViewer/url-selection.ts
@@ -3,7 +3,9 @@ export const getUrlSelectedFileFromLocation = (
   hash: string,
 ): string | null => {
   const searchParams = new URLSearchParams(search)
-  const hashParams = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash)
+  const hashParams = new URLSearchParams(
+    hash.startsWith("#") ? hash.slice(1) : hash,
+  )
 
   return (
     hashParams.get("file") ??
@@ -17,7 +19,9 @@ export const getUpdatedHashForFileSelection = (
   hash: string,
   filePath: string,
 ): string | null => {
-  const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash)
+  const params = new URLSearchParams(
+    hash.startsWith("#") ? hash.slice(1) : hash,
+  )
 
   if (
     params.get("file") === filePath &&

--- a/tests/runframe-static-build-viewer-url-selection.test.ts
+++ b/tests/runframe-static-build-viewer-url-selection.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  getUpdatedHashForFileSelection,
+  getUrlSelectedFileFromLocation,
+} from "../lib/components/RunFrameStaticBuildViewer/url-selection"
+
+describe("RunFrameStaticBuildViewer URL selection", () => {
+  test("prefers hash file over stale query file", () => {
+    expect(
+      getUrlSelectedFileFromLocation("?file=old.tsx", "#file=new.tsx"),
+    ).toBe("new.tsx")
+  })
+
+  test("falls back to main_component in hash", () => {
+    expect(
+      getUrlSelectedFileFromLocation(
+        "",
+        "#main_component=lib%2Fsubcircuits%2FBQ24074-subcircuit.circuit.tsx",
+      ),
+    ).toBe("lib/subcircuits/BQ24074-subcircuit.circuit.tsx")
+  })
+
+  test("falls back to query params when hash has no file selection", () => {
+    expect(
+      getUrlSelectedFileFromLocation("?main_component=lib%2Fmain.circuit.tsx", ""),
+    ).toBe("lib/main.circuit.tsx")
+  })
+
+  test("updates both file and main_component when main_component exists", () => {
+    expect(
+      getUpdatedHashForFileSelection(
+        "#file=old.tsx&main_component=old.tsx",
+        "new.tsx",
+      ),
+    ).toBe("#file=new.tsx&main_component=new.tsx")
+  })
+
+  test("does not rewrite hash when file selection is already current", () => {
+    expect(
+      getUpdatedHashForFileSelection(
+        "#file=current.tsx&main_component=current.tsx",
+        "current.tsx",
+      ),
+    ).toBeNull()
+  })
+})

--- a/tests/runframe-static-build-viewer-url-selection.test.ts
+++ b/tests/runframe-static-build-viewer-url-selection.test.ts
@@ -23,7 +23,10 @@ describe("RunFrameStaticBuildViewer URL selection", () => {
 
   test("falls back to query params when hash has no file selection", () => {
     expect(
-      getUrlSelectedFileFromLocation("?main_component=lib%2Fmain.circuit.tsx", ""),
+      getUrlSelectedFileFromLocation(
+        "?main_component=lib%2Fmain.circuit.tsx",
+        "",
+      ),
     ).toBe("lib/main.circuit.tsx")
   })
 


### PR DESCRIPTION
## Summary
- read the selected static-viewer file from both  and 
- prefer hash parameters over query parameters so in-app navigation remains canonical
- keep  synchronized in the hash when that parameter already exists

## Why
Production links can use , while local and in-app navigation use . This keeps static viewer deep links stable across reloads and file changes.

## Testing
- not run (no dedicated test script in )
