### PR TITLE
Add flag to hide schematic in analog simulation

### DIFF
--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -134,6 +134,7 @@ export const CircuitJsonPreview = ({
   isCli = false,
   projectName,
   schematicSvgOptions,
+  hideSchematicInAnalogSimulation = false,
   onRerunWithDebug,
   solverEvents,
   onPcbBoundsSelected,
@@ -779,6 +780,7 @@ export const CircuitJsonPreview = ({
                     ) : (
                       <AnalogSimulationViewer
                         circuitJson={circuitJson}
+                        hideSchematic={hideSchematicInAnalogSimulation}
                         containerStyle={{
                           height: "100%",
                         }}

--- a/lib/components/CircuitJsonPreview/PreviewContentProps.ts
+++ b/lib/components/CircuitJsonPreview/PreviewContentProps.ts
@@ -39,6 +39,11 @@ export interface PreviewContentProps {
     css?: string
     className?: string
   }
+  /**
+   * Hide the schematic in the analog simulation view and show only the graph.
+   * Defaults to false.
+   */
+  hideSchematicInAnalogSimulation?: boolean
   showCodeTab?: boolean
   showRenderLogTab?: boolean
   codeTabContent?: React.ReactNode


### PR DESCRIPTION
## Summary

- add `hideSchematicInAnalogSimulation` to `CircuitJsonPreview`
- default the new flag to `false` to preserve existing rendering
- forward the flag to `AnalogSimulationViewer.hideSchematic`

## Why

`AnalogSimulationViewer` supports graph-only rendering, but `CircuitJsonPreview` previously had no way for consumers to select it.

## Impact

Existing callers continue to see the combined schematic and simulation graph. Consumers can opt into graph-only rendering with:

```tsx
<CircuitJsonPreview
  circuitJson={circuitJson}
  hideSchematicInAnalogSimulation
/>
```

## Validation

- `bun run format:check`
- `bun test` — 29 tests passed
- `bun run build:lib`