### PR TITLE
update easyeda to 0.0.275

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
         "debug": "^4.4.0",
-        "easyeda": "^0.0.269",
+        "easyeda": "^0.0.275",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -967,7 +967,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.269", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-uhtMsYxs6K3V82CS18cw5pCPJ45KYqoc4HzMnrA0pIFWAPO6fEd1Z/w0QBK803ngEtiD+GIVjIZm4REKxzQiEQ=="],
+    "easyeda": ["easyeda@0.0.275", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-fzM5mzM1vrh6Pll+4JMKDSyFmnnKjCvIDbWuaqu3gxmquRbpbqYYbwt03/u7OEryROQw3N+P3vKjQt4pjo+QpA=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
     "debug": "^4.4.0",
-    "easyeda": "^0.0.269",
+    "easyeda": "^0.0.275",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary

- update `easyeda` from `^0.0.269` to `^0.0.275`
- refresh the Bun lockfile entry and integrity hash

## Why

Keeps Runframe on the latest published `easyeda` release while preserving the existing semver range style.

## Impact

Runframe now resolves `easyeda` 0.0.275. No application code changes are included.

## Validation

- `bun install --frozen-lockfile`
- `bun run format:check`
- `bun run build`
- `bun test` (29 passed)