### PR TITLE
Support direct JLCPCB part imports (even if not on jlcsearch)

### DIFF
--- a/lib/components/ImportComponentDialog2/components/SearchResultsList.tsx
+++ b/lib/components/ImportComponentDialog2/components/SearchResultsList.tsx
@@ -1,6 +1,6 @@
+import type { Package } from "@tscircuit/fake-snippets/schema"
 import { Lock } from "lucide-react"
 import { Button } from "../../ui/button"
-import type { Package } from "@tscircuit/fake-snippets/schema"
 import type {
   ImportComponentDialogSearchResult,
   TscircuitPackageSearchResult,
@@ -45,7 +45,9 @@ const getPrimaryText = (result: ImportComponentDialogSearchResult) => {
     case "tscircuit.com":
       return result.package.unscoped_name
     case "jlcpcb":
-      return result.component.manufacturer
+      return result.component.isDirectLookup
+        ? result.component.partNumber
+        : result.component.manufacturer
     case "kicad":
       return result.footprint.qualifiedName
   }
@@ -72,7 +74,9 @@ const getPartNumberLabel = (result: ImportComponentDialogSearchResult) => {
     case "tscircuit.com":
       return result.package.name
     case "jlcpcb":
-      return result.component.partNumber
+      return result.component.isDirectLookup
+        ? undefined
+        : result.component.partNumber
     case "kicad":
       return undefined
   }
@@ -98,6 +102,8 @@ export const SearchResultsList = ({
         const price = result.source === "jlcpcb" ? result.component.price : null
         const isBasic =
           result.source === "jlcpcb" ? result.component.isBasic : null
+        const isDirectLookup =
+          result.source === "jlcpcb" ? result.component.isDirectLookup : false
 
         return (
           <div
@@ -118,6 +124,11 @@ export const SearchResultsList = ({
                       }`}
                     >
                       {isBasic ? "Basic" : "Extended"}
+                    </span>
+                  )}
+                  {isDirectLookup && (
+                    <span className="rf-text-xs rf-px-1.5 rf-py-0.5 rf-rounded rf-font-medium rf-flex-shrink-0 rf-bg-blue-100 rf-text-blue-700">
+                      Direct lookup
                     </span>
                   )}
                   {result.source === "tscircuit.com" &&

--- a/lib/components/ImportComponentDialog2/config.ts
+++ b/lib/components/ImportComponentDialog2/config.ts
@@ -14,7 +14,7 @@ export const SOURCE_CONFIG: Record<ImportSource, SourceConfig> = {
   },
   jlcpcb: {
     label: "JLCPCB Parts",
-    placeholder: "Search JLCPCB parts (e.g. C14663)...",
+    placeholder: "Search JLCPCB parts or enter an exact LCSC ID...",
     emptyMessage: "No parts found",
   },
   kicad: {

--- a/lib/components/ImportComponentDialog2/config.ts
+++ b/lib/components/ImportComponentDialog2/config.ts
@@ -14,7 +14,7 @@ export const SOURCE_CONFIG: Record<ImportSource, SourceConfig> = {
   },
   jlcpcb: {
     label: "JLCPCB Parts",
-    placeholder: "Search JLCPCB parts or enter an exact LCSC ID...",
+    placeholder: "Search JLCPCB parts (e.g. C14663)...",
     emptyMessage: "No parts found",
   },
   kicad: {

--- a/lib/components/ImportComponentDialog2/direct-jlcpcb-lookup.ts
+++ b/lib/components/ImportComponentDialog2/direct-jlcpcb-lookup.ts
@@ -1,0 +1,42 @@
+import type { JlcpcbComponentSearchResult } from "./types"
+
+export const createDirectJlcpcbLookupResult = (
+  query: string,
+): JlcpcbComponentSearchResult | null => {
+  const match = /^C(\d+)$/i.exec(query.trim())
+  if (!match) return null
+
+  const lcscId = Number(match[1])
+  if (!Number.isSafeInteger(lcscId)) return null
+
+  const partNumber = `C${match[1]}`
+
+  return {
+    source: "jlcpcb",
+    component: {
+      lcscId,
+      manufacturer: partNumber,
+      partNumber,
+      description:
+        "Import directly from EasyEDA; stock and availability are unknown",
+      package: "",
+      isDirectLookup: true,
+    },
+  }
+}
+
+export const addDirectJlcpcbLookupResult = (
+  query: string,
+  results: JlcpcbComponentSearchResult[],
+): JlcpcbComponentSearchResult[] => {
+  const directResult = createDirectJlcpcbLookupResult(query)
+  if (!directResult) return results
+
+  const alreadyIncluded = results.some(
+    (result) =>
+      result.component.partNumber.toUpperCase() ===
+      directResult.component.partNumber,
+  )
+
+  return alreadyIncluded ? results : [directResult, ...results]
+}

--- a/lib/components/ImportComponentDialog2/hooks/useJlcpcbComponentSearch.ts
+++ b/lib/components/ImportComponentDialog2/hooks/useJlcpcbComponentSearch.ts
@@ -3,6 +3,7 @@ import {
   mapJlcpcbComponentToSummary,
   searchJlcpcbComponents,
 } from "../api/jlcpcb"
+import { addDirectJlcpcbLookupResult } from "../direct-jlcpcb-lookup"
 import type { JlcpcbComponentSearchResult } from "../types"
 
 const normalizeQuery = (query: string) => {
@@ -29,21 +30,27 @@ export const useJlcpcbComponentSearch = () => {
 
     try {
       const components = await searchJlcpcbComponents(normalizedQuery, 10)
-      const mappedResults = components.map((component) => ({
-        source: "jlcpcb" as const,
-        component: mapJlcpcbComponentToSummary(component),
-      }))
+      const mappedResults = addDirectJlcpcbLookupResult(
+        query,
+        components.map((component) => ({
+          source: "jlcpcb" as const,
+          component: mapJlcpcbComponentToSummary(component),
+        })),
+      )
       setResults(mappedResults)
       return mappedResults
     } catch (error) {
       console.error("Error searching JLCPCB components", error)
-      setResults([])
+      const directResults = addDirectJlcpcbLookupResult(query, [])
+      setResults(directResults)
       setError(
-        error instanceof Error
-          ? error.message
-          : "Failed to search JLCPCB components",
+        directResults.length > 0
+          ? null
+          : error instanceof Error
+            ? error.message
+            : "Failed to search JLCPCB components",
       )
-      return []
+      return directResults
     } finally {
       setIsSearching(false)
       setHasSearched(true)

--- a/lib/components/ImportComponentDialog2/types.ts
+++ b/lib/components/ImportComponentDialog2/types.ts
@@ -22,6 +22,7 @@ export interface JlcpcbComponentSummary {
   price?: number
   stock?: number
   isBasic?: boolean // true = basic, false = extended
+  isDirectLookup?: boolean
 }
 
 export interface JlcpcbComponentSearchResult {

--- a/tests/direct-jlcpcb-lookup.test.ts
+++ b/tests/direct-jlcpcb-lookup.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import {
+  addDirectJlcpcbLookupResult,
+  createDirectJlcpcbLookupResult,
+} from "../lib/components/ImportComponentDialog2/direct-jlcpcb-lookup"
+import type { JlcpcbComponentSearchResult } from "../lib/components/ImportComponentDialog2/types"
+
+describe("direct JLCPCB lookup", () => {
+  test("creates a direct result for an exact LCSC part number", () => {
+    expect(createDirectJlcpcbLookupResult(" c5264268 ")).toEqual({
+      source: "jlcpcb",
+      component: {
+        lcscId: 5264268,
+        manufacturer: "C5264268",
+        partNumber: "C5264268",
+        description:
+          "Import directly from EasyEDA; stock and availability are unknown",
+        package: "",
+        isDirectLookup: true,
+      },
+    })
+  })
+
+  test("does not create direct results for general searches", () => {
+    expect(createDirectJlcpcbLookupResult("ISP1807-LR-RS")).toBeNull()
+    expect(createDirectJlcpcbLookupResult("5264268")).toBeNull()
+    expect(createDirectJlcpcbLookupResult("C5264268 extra")).toBeNull()
+  })
+
+  test("adds a direct fallback when JLCSearch omits the exact part", () => {
+    const results = addDirectJlcpcbLookupResult("C5264268", [])
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.component.partNumber).toBe("C5264268")
+    expect(results[0]?.component.isDirectLookup).toBe(true)
+  })
+
+  test("does not duplicate a part returned by JLCSearch", () => {
+    const catalogResult: JlcpcbComponentSearchResult = {
+      source: "jlcpcb",
+      component: {
+        lcscId: 14663,
+        manufacturer: "RC0603FR-0710KL",
+        partNumber: "C14663",
+        description: "10k resistor",
+        package: "0603",
+        stock: 100,
+      },
+    }
+
+    expect(addDirectJlcpcbLookupResult("C14663", [catalogResult])).toEqual([
+      catalogResult,
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- surface a direct EasyEDA lookup result when an exact LCSC `C…` query is absent from JLCSearch
- reuse the existing EasyEDA footprint preview and TSX import pipeline
- label fallback results as direct lookups without claiming stock or pricing data
- cover exact-ID creation, general searches, fallback insertion, and duplicate prevention

## Root cause

The import dialog only exposed results returned by JLCSearch. Because JLCSearch is optimized for in-stock catalog discovery, valid EasyEDA/LCSC parts such as out-of-stock parts could not be selected and therefore never reached runframe's existing direct EasyEDA importer.

## Impact

Users can now enter an exact LCSC part number and import it even when it is out of stock or otherwise absent from JLCSearch. General component searches continue to use the existing ranked JLCSearch results.

## Validation

- `bun test` — 33 passed
- `bunx tsc --noEmit`
- Biome check on changed files
- `bun run build:lib`
