### PR TITLE
fix: include directional battery symbols in standalone bundle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
         "redaxios": "^0.5.1",
         "rollup-plugin-visualizer": "^5.12.0",
         "s-expression": "^3.1.1",
-        "schematic-symbols": "^0.0.231",
+        "schematic-symbols": "^0.0.233",
         "serve": "^14.2.4",
         "source-map-explorer": "^2.5.3",
         "stepts": "^0.0.3",
@@ -1697,7 +1697,7 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "schematic-symbols": ["schematic-symbols@0.0.231", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-3NqAflroTZOT5I8WZRFbqml7zzZ7svUnYi1rp2DeaZnAegz+7Jb9qd+vcDrsyL5tRrmGf6ERDFLxhSkvbC9jsA=="],
+    "schematic-symbols": ["schematic-symbols@0.0.233", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-RW+gYkjqIEvB/9sEvkz0WeakAgVhrP0i1WpVnMi9Blblkrm3p4aQoc4oLgotbv3dlyXGPdjIiNED96wzky1ong=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redaxios": "^0.5.1",
     "rollup-plugin-visualizer": "^5.12.0",
     "s-expression": "^3.1.1",
-    "schematic-symbols": "^0.0.231",
+    "schematic-symbols": "^0.0.233",
     "serve": "^14.2.4",
     "source-map-explorer": "^2.5.3",
     "stepts": "^0.0.3",


### PR DESCRIPTION
## What changed

- Update `schematic-symbols` from `^0.0.231` to `^0.0.233`.
- Regenerate `bun.lock`.

## Why

Newer tscircuit workers emit directional battery symbol names such as `battery_down` for rotated batteries. The RunFrame standalone bundle was still built with `schematic-symbols@0.0.231`, which only includes the legacy `battery_horz` and `battery_vert` symbols. This caused live schematic previews to show `Symbol not found: battery_down` even though command-line SVG snapshots rendered the battery.

Updating the bundle dependency keeps the RunFrame renderer aligned with the evaluator and makes all directional battery symbols available in live schematics.

## Validation

- `bun run build:standalone`
- Verified `dist/standalone.min.js` contains `battery_down`, `battery_up`, `battery_left`, `battery_right`, `battery_horz`, and `battery_vert`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun test` — 33 passed, 0 failed