### PR TITLE
fix duplicate 3D orientation canvas in iframe

### DIFF
--- a/lib/entrypoints/iframe.tsx
+++ b/lib/entrypoints/iframe.tsx
@@ -1,6 +1,6 @@
 import type { RunFrameIframeEvent } from "lib/components/RunFrameWithIframe/RunFrameIframeEvent"
 import { RunFrame, type RunFrameProps } from "lib/runner"
-import React, { useEffect, useReducer, useState } from "react"
+import { useEffect, useReducer, useState } from "react"
 import { createRoot } from "react-dom/client"
 
 const root = createRoot(document.getElementById("root")!)
@@ -58,8 +58,4 @@ function IframeApp() {
   )
 }
 
-root.render(
-  <React.StrictMode>
-    <IframeApp />
-  </React.StrictMode>,
-)
+root.render(<IframeApp />)


### PR DESCRIPTION
## Summary

- render the standalone iframe entrypoint without React Strict Mode
- prevent the 3D viewer's imperative orientation-canvas effect from being replayed in production
- remove the stray broken-looking canvas and keep the view cube in its intended top-left position

## Root cause

The standalone iframe entrypoint wrapped `IframeApp` in `React.StrictMode`. Strict Mode replays effects, while `@tscircuit/3d-viewer` creates its orientation canvas imperatively. In the iframe build this left two 120×120 canvases in the orientation-control container: a stale canvas at the top and the real view cube pushed down by 120px.

The production iframe does not need Strict Mode, so mounting `IframeApp` once avoids replaying this imperative integration.

## Validation

- `bun test` — 34 tests passed
- `bun run format:check`
- `bun run build:iframe`
- browser verification against `example09-iframe.fixture.tsx`: orientation container changed from two canvases to one, and the stray box disappeared