### PR TITLE
Bump eval to 0.0.1071

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@tscircuit/runframe",
       "dependencies": {
-        "@tscircuit/eval": "^0.0.1070",
+        "@tscircuit/eval": "^0.0.1071",
         "@tscircuit/solver-utils": "^0.0.7",
       },
       "devDependencies": {
@@ -558,7 +558,7 @@
 
     "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.9", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-CI+PDOy28Q9pycIyjx0vLpnh6wuyocYPMAJqhr/uAbOBBdY3sz3zTWHvdy7giqTGo0+v5x0nhN6o60RT82grZA=="],
 
-    "@tscircuit/eval": ["@tscircuit/eval@0.0.1070", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-Tnx6vR4uCWe1VNPQ3PGjnp7B+XhC43jHRGAPGyfgkq0dRctmWovfZISeswvL7Ih5ofmPVngpB/pF1c2etG6XCg=="],
+    "@tscircuit/eval": ["@tscircuit/eval@0.0.1071", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-Hn6gpjbw1txveIUXMflc1emEB1A1MJZhocMUiolxtDZlL3pcnHJMZ9nemIyjIDVuy7ibWt8xXMIyCfphc9M2lA=="],
 
     "@tscircuit/fake-snippets": ["@tscircuit/fake-snippets@0.0.163", "", {}, "sha512-E/ZvC5CRfgG/Q6776ovR4oZuLgXbSxpvffminIwpTE1axg+vrNdOz2RzGBHbZCIcDUhs4etmB85kAizuiNJSBw=="],
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@tscircuit/eval": "^0.0.1070",
+    "@tscircuit/eval": "^0.0.1071",
     "@tscircuit/solver-utils": "^0.0.7"
   }
 }


### PR DESCRIPTION
## Summary

Bump `@tscircuit/eval` from `0.0.1070` to `0.0.1071` and update the Bun lockfile.

## Why

Eval 0.0.1071 includes parts-engine 0.0.24, which carries EasyEDA 0.0.277 and preserves failed proxy HTTP statuses in propagated component-search errors.

## Validation

Not run, per request; this PR contains only the dependency and lockfile update.