### PR TITLE
Bump eval to 0.0.1074

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@tscircuit/runframe",
       "dependencies": {
-        "@tscircuit/eval": "^0.0.1073",
+        "@tscircuit/eval": "^0.0.1074",
         "@tscircuit/solver-utils": "^0.0.7",
       },
       "devDependencies": {
@@ -558,7 +558,7 @@
 
     "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.9", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-CI+PDOy28Q9pycIyjx0vLpnh6wuyocYPMAJqhr/uAbOBBdY3sz3zTWHvdy7giqTGo0+v5x0nhN6o60RT82grZA=="],
 
-    "@tscircuit/eval": ["@tscircuit/eval@0.0.1073", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-scSvDYvlizMQljdLVoxbO+v5jcD1GDxKDG4EvC3mrW8sVFgYw7fqXLyoQ4vD8W1efntlyYHnr+iVCjs24rIFUg=="],
+    "@tscircuit/eval": ["@tscircuit/eval@0.0.1074", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-8R5SCVl0/VsmwOs4onb5I3CxGcCD3U7nQMUEcB11OZs/DgE1ymlR98N1McyGogicOwGtYJodSzTqPdmASmXFVw=="],
 
     "@tscircuit/fake-snippets": ["@tscircuit/fake-snippets@0.0.163", "", {}, "sha512-E/ZvC5CRfgG/Q6776ovR4oZuLgXbSxpvffminIwpTE1axg+vrNdOz2RzGBHbZCIcDUhs4etmB85kAizuiNJSBw=="],
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@tscircuit/eval": "^0.0.1073",
+    "@tscircuit/eval": "^0.0.1074",
     "@tscircuit/solver-utils": "^0.0.7"
   }
 }


### PR DESCRIPTION
## What changed

- Bump `@tscircuit/eval` from `^0.0.1073` to `^0.0.1074`.
- Update only the matching direct dependency and resolved eval entry in `bun.lock`.

## Why

eval 0.0.1074 includes parts-engine 0.0.25, which preserves EasyEDA proxy authentication error codes for downstream handling.

## Impact

No runframe logic or public API changes. This only updates the eval implementation consumed by runframe.

## Validation

- `bun run format:check`
- `bun run build`