### PR TITLE
bun install should work out of the box

### DIFF
--- a/.github/workflows/bun-library-consumption.yml
+++ b/.github/workflows/bun-library-consumption.yml
@@ -1,0 +1,62 @@
+name: Bun Library Consumption Test
+
+on:
+  pull_request:
+
+jobs:
+  # This library consumption smoke test
+  # tests direct API use case
+  # rather than standalone or iframe consumption
+  library-consumption:
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.title != 'chore: bump version' }}"
+    timeout-minutes: 10
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build package
+        run: bun run build
+
+      - name: Pack package
+        run: bun pm pack
+
+      - name: Test library consumption in blank Vite app
+        run: |
+          cd /tmp
+          bun create vite test-app --template react-ts --no-install --no-interactive
+          cd test-app
+          bun install
+          bun add ${{ github.workspace }}/tscircuit-runframe-*.tgz
+          
+          cat > src/App.tsx <<'EOF'
+          import { RunFrame } from "@tscircuit/runframe/runner"
+          import { CircuitJsonPreview } from "@tscircuit/runframe/preview"
+          
+          function App() {
+            return (
+              <div style={{ width: "100vw", height: "100vh" }}>
+                <RunFrame
+                  fsMap={{ "main.tsx": "circuit.add(<resistor resistance='1k' />)" }}
+                  entrypoint="main.tsx"
+                />
+                <CircuitJsonPreview circuitJson={[]} />
+              </div>
+            )
+          }
+          
+          export default App
+          EOF
+          
+          bun run build
+          bunx tsc --noEmit


### PR DESCRIPTION
Let's create a smoke test first to demostrate the issue.


A minimal PR smoke test looks like this:
```bash
# In the runframe repo  
bun run build  
bun pack  
  
# In a blank consumer app  
cd /tmp  
bun create vite test-app --template react-ts  
cd test-app  
bun add /path/to/runframe/tscircuit-runframe-*.tgz
```
App.tsx:
```tsx
import { RunFrame } from "@tscircuit/runframe/runner"  
import { CircuitJsonPreview } from "@tscircuit/runframe/preview"  
  
function App() {  
  return (  
    <div style={{ width: "100vw", height: "100vh" }}>  
      <RunFrame  
        fsMap={{ "main.tsx": "circuit.add(<resistor resistance='1k' />)" }}  
        entrypoint="main.tsx"  
      />  
      <CircuitJsonPreview circuitJson={[]} style={{ display: "none" }} />  
    </div>  
  )  
}  
  
export default App
```

Related github workflows: `bun-pver-release.yml`, `bun-test.yml`.

This really a release concern, but we'd probably also want to test that each PR would create a working release, as releases apparently published after each PR merge. So `bun-test.yml` is probably correct destination. Another approach is to create `bun-library-consumption.yml` as a standalone reusable workflow.


Explanation:
- bun install & bun build produces the build artifact
- bun pack produces tscircuit-runframe-0.0.2296.tgz in the repo root, so that it's ready to upload to npm
- bun add ./tscircuit-runframe-*.tgz installs the package as if it was published to npm
- you create a template project, add runframe to it using bun add, import it using example above, and run bun run dev or bun build to test if it compiles.
- if it doesn't compile we deduce runframe doesn't work OOTB with bun install
