### PR TITLE
Add Matchpack to the Solvers tab

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@tscircuit/runframe",
       "dependencies": {
         "@tscircuit/eval": "^0.0.1106",
+        "@tscircuit/matchpack": "^0.0.64",
         "@tscircuit/solver-utils": "^0.0.7",
         "debug": "^4.4.0",
       },
@@ -578,7 +579,7 @@
 
     "@tscircuit/manifold-2d": ["@tscircuit/manifold-2d@0.0.6", "", {}, "sha512-kYny1hDwPHOwRfMQtbfLh0nvCQ7nM91kkHy7pnj1UrqM6rcgDymZVCZB7ib5Cx1aZFIs8xCCF7lA51tq+giDcw=="],
 
-    "@tscircuit/matchpack": ["@tscircuit/matchpack@0.0.43", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-X0V2d9N1TiJncjB4jhsqrHUSX0HfQ1IAfsHxVZTV4h1wEbTtrO5tluX22Pjlul6pQecKBBCzt3Nje5O5eEAZHQ=="],
+    "@tscircuit/matchpack": ["@tscircuit/matchpack@0.0.64", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-p6YM1Aicv/CfSMuO9qX9UFdKQemFg8GXLG7Kb7CnkNOWefbt8Z3k+AmaGB6OlIG3ZJUckeY241YgxD9tgei3wA=="],
 
     "@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.36", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HwHS3do6CLQFnLGd0f3+kQzGfENFllpt5ZFWF9gfw2k5Rc5VSxSJi8/MLfHEgaMgrnMCZ5Hqh3DlUD6U3pMXyg=="],
 
@@ -2181,6 +2182,8 @@
     "tscircuit/@tscircuit/eval": ["@tscircuit/eval@0.0.1050", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-xuOkFjYLNIDpig2hcGcI0mQs39p1P+icZuBvgiRf+oZZnw8VfGzVwMU/erIrLpOFmlqg4X1PUIFZZ13L5NpPEg=="],
 
     "tscircuit/@tscircuit/internal-dynamic-import": ["@tscircuit/internal-dynamic-import@0.0.11", "", {}, "sha512-Tr72DhEGXwysbe2PZ0+GiLC8/pGp0BA9Dl+2xTXxaukwcGam08+PMJF+AJpIOfXjafP6S1OZf1HmciDeD8PydA=="],
+
+    "tscircuit/@tscircuit/matchpack": ["@tscircuit/matchpack@0.0.43", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-X0V2d9N1TiJncjB4jhsqrHUSX0HfQ1IAfsHxVZTV4h1wEbTtrO5tluX22Pjlul6pQecKBBCzt3Nje5O5eEAZHQ=="],
 
     "tscircuit/@tscircuit/solver-utils": ["@tscircuit/solver-utils@0.0.16", "", { "peerDependencies": { "graphics-debug": "*", "typescript": "^5" } }, "sha512-paeEsPt+NOrIdeEb1PQpoNGjl9bD5MfcDaBuhFkn7Hdsxez4cXhKUyxWj3WbJsZzq9nUDW3Utr/Dl3GD4UURZQ=="],
 

--- a/lib/components/SolversTabContent/SolversTabContent.tsx
+++ b/lib/components/SolversTabContent/SolversTabContent.tsx
@@ -1,4 +1,3 @@
-import { SOLVERS } from "@tscircuit/core"
 import { GenericSolverDebugger } from "@tscircuit/solver-utils/react"
 import { Box, BugIcon, DownloadIcon, LayoutGrid, Route } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -8,6 +7,7 @@ import { openForDownload } from "../../optional-features/exporting/open-for-down
 import { sanitizeFileName } from "../../utils/sanitizeFileName"
 import type { SolverStartedEvent } from "../CircuitJsonPreview/PreviewContentProps"
 import { Button } from "../ui/button"
+import { getRunframeSolverClass, RUNFRAME_SOLVERS } from "./solver-registry"
 
 interface SolversTabContentProps {
   solverEvents?: SolverStartedEvent[]
@@ -25,11 +25,14 @@ const COPPER_POUR_REPORT_LINK =
   "https://github.com/tscircuit/copper-pour-solver/issues/new"
 const PACK_SOLVER_REPORT_LINK =
   "https://github.com/tscircuit/calculate-packing/issues/new"
+const MATCHPACK_REPORT_LINK =
+  "https://github.com/tscircuit/matchpack/issues/new"
 const SCHEMATIC_TRACE_REPORT_LINK =
   "https://github.com/tscircuit/schematic-trace-solver/issues/new?template=json-bug-report.yml"
 
 const SOLVER_REPORT_LINKS: Record<string, string> = {
   PackSolver2: PACK_SOLVER_REPORT_LINK,
+  LayoutPipelineSolver: MATCHPACK_REPORT_LINK,
   AutoroutingPipelineSolver: AUTOROUTER_REPORT_LINK,
   AssignableAutoroutingPipeline2: AUTOROUTER_REPORT_LINK,
   AssignableAutoroutingPipeline3: AUTOROUTER_REPORT_LINK,
@@ -188,13 +191,11 @@ export const SolversTabContent = ({
       return { instance: null, error: null, classFound: false }
     }
 
-    const SolverClass = (SOLVERS as Record<string, any>)[
-      selectedSolverEvent.solverName
-    ]
+    const SolverClass = getRunframeSolverClass(selectedSolverEvent.solverName)
     if (!SolverClass) {
       return {
         instance: null,
-        error: `Solver class "${selectedSolverEvent.solverName}" not found in SOLVERS registry. Available: ${Object.keys(SOLVERS).join(", ")}`,
+        error: `Solver class "${selectedSolverEvent.solverName}" not found in solver registry. Available: ${Object.keys(RUNFRAME_SOLVERS).join(", ")}`,
         classFound: false,
       }
     }
@@ -203,7 +204,7 @@ export const SolversTabContent = ({
       // HACK: if "input" is in the result, use that as the constructor parameter
       const params = selectedSolverEvent.solverParams as Record<string, unknown>
       const constructorArg = params?.input !== undefined ? params.input : params
-      const instance = new SolverClass(constructorArg)
+      const instance = new SolverClass(constructorArg as never)
       return { instance, error: null, classFound: true }
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e)

--- a/lib/components/SolversTabContent/solver-registry.ts
+++ b/lib/components/SolversTabContent/solver-registry.ts
@@ -1,0 +1,12 @@
+import { SOLVERS } from "@tscircuit/core"
+import { LayoutPipelineSolver } from "@tscircuit/matchpack"
+
+export const RUNFRAME_SOLVERS = {
+  ...SOLVERS,
+  LayoutPipelineSolver,
+}
+
+type SolverConstructor = new (solverInput: never) => object
+
+export const getRunframeSolverClass = (solverName: string) =>
+  (RUNFRAME_SOLVERS as Record<string, SolverConstructor>)[solverName]

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "dependencies": {
     "@tscircuit/eval": "^0.0.1106",
+    "@tscircuit/matchpack": "^0.0.64",
     "@tscircuit/solver-utils": "^0.0.7",
     "debug": "^4.4.0"
   }

--- a/tests/solver-registry.test.ts
+++ b/tests/solver-registry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "@tscircuit/matchpack"
+import {
+  getRunframeSolverClass,
+  RUNFRAME_SOLVERS,
+} from "../lib/components/SolversTabContent/solver-registry"
+
+describe("runframe solver registry", () => {
+  test("includes Matchpack's LayoutPipelineSolver", () => {
+    expect(getRunframeSolverClass("LayoutPipelineSolver")).toBe(
+      LayoutPipelineSolver,
+    )
+    expect(RUNFRAME_SOLVERS.LayoutPipelineSolver).toBe(LayoutPipelineSolver)
+  })
+
+  test("retains solvers supplied by @tscircuit/core", () => {
+    expect(getRunframeSolverClass("PackSolver2")).toBeFunction()
+  })
+})


### PR DESCRIPTION
### Motivation

Runframe reconstructs solver instances from `solver:started` events so users can inspect them in the Solvers tab. Matchpack's `LayoutPipelineSolver` is not part of `@tscircuit/core`'s exported solver registry, so a Matchpack event cannot currently open its debugger.

### Change

- add a Runframe solver registry that extends the core registry with Matchpack's `LayoutPipelineSolver`
- use that registry when reconstructing solver instances
- route Matchpack bug reports to `tscircuit/matchpack`
- add `@tscircuit/matchpack` as a direct dependency

### Evidence

The focused registry test verifies that `LayoutPipelineSolver` resolves to the Matchpack implementation while existing core solvers remain available.

This prepares Runframe to display Matchpack events once `@tscircuit/core` emits `solver:started` for `LayoutPipelineSolver`.

### Tests

- `bun test` — 36 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`