### PR TITLE
Fix Ctrl/Cmd+Enter execution when Monaco consumes the shortcut

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -142,11 +142,14 @@ export const RunFrame = (props: RunFrameProps) => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "Enter" && !isRunning) {
+        e.preventDefault()
+        e.stopPropagation()
         incRunCountTrigger(1)
       }
     }
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
+    window.addEventListener("keydown", handleKeyDown, { capture: true })
+    return () =>
+      window.removeEventListener("keydown", handleKeyDown, { capture: true })
   }, [isRunning])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes a keyboard shortcut bug that prevented RunFrame from executing code with Ctrl+Enter or Cmd+Enter while Monaco had focus.

## Reproduction

1. Open RunFrame with the Monaco editor.
2. Focus the editor.
3. Press Ctrl+Enter on Windows/Linux or Cmd+Enter on macOS.
4. RunFrame does not execute because Monaco consumes the keyboard event before it reaches the existing listener.

## Fix

- Listen for the shortcut during the capture phase so RunFrame receives it before Monaco.
- Prevent Monaco's default behavior when the shortcut is triggered.
- Stop further propagation to avoid duplicate or conflicting actions.
- Preserve the existing guard that prevents another execution while code is already running.

## User impact

Users can now reliably run code with Ctrl/Cmd+Enter without leaving the editor, restoring the advertised shortcut and improving the core editing workflow.

## Testing

Manually verified by applying the change as a patch on tscircuit.com.

Confirmed that Ctrl/Cmd+Enter runs code while Monaco is focused and does not trigger Monaco's default behavior.

`bun run build:lib` successfully builds the JavaScript bundles, but declaration generation is currently blocked by an unrelated existing `hideSchematic` type error in `CircuitJsonPreview.tsx`.
