### PR TITLE
Manage the CLI cache in RunFrame

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -170,7 +170,7 @@ export const RunFrame = (props: RunFrameProps) => {
                 props.projectBaseUrl || `${API_BASE}/files/static`,
             },
             ...(props.platformConfig && {
-              platformConfig: props.platformConfig,
+              platform: props.platformConfig,
             }),
             verbose: true,
             ...(props.enableFetchProxy && {
@@ -329,7 +329,7 @@ export const RunFrame = (props: RunFrameProps) => {
             projectBaseUrl: props.projectBaseUrl || `${API_BASE}/files/static`,
           },
           ...(props.platformConfig && {
-            platformConfig: props.platformConfig,
+            platform: props.platformConfig,
           }),
           ...(props.enableFetchProxy && {
             enableFetchProxy: props.enableFetchProxy,

--- a/lib/components/RunFrameForCli/RunFrameForCli.tsx
+++ b/lib/components/RunFrameForCli/RunFrameForCli.tsx
@@ -1,18 +1,39 @@
 import { useLocalStorageState } from "lib/hooks/use-local-storage-state"
-import { useCallback, useState } from "react"
-import { RunFrameWithApi } from "../RunFrameWithApi/RunFrameWithApi"
+import { useCallback, useMemo, useState } from "react"
 import { FileMenuLeftHeader } from "../FileMenuLeftHeader"
+import {
+  RunFrameWithApi,
+  type RunFrameWithApiProps,
+} from "../RunFrameWithApi/RunFrameWithApi"
+import { API_BASE } from "../RunFrameWithApi/api-base"
 import { useLoginDialog } from "./LoginDialog"
+import { createCliLocalCacheEngine } from "./create-cli-local-cache-engine"
 
-export const RunFrameForCli = (props: {
+export interface RunFrameForCliProps {
   debug?: boolean
   scenarioSelectorContent?: React.ReactNode
   workerBlobUrl?: string
+  evalWebWorkerBlobUrl?: string
   enableFetchProxy?: boolean
-}) => {
+  apiBaseUrl?: string
+  platformConfig?: RunFrameWithApiProps["platformConfig"]
+}
+
+export const RunFrameForCli = (props: RunFrameForCliProps) => {
   const [shouldLoadLatestEval, setLoadLatestEval] = useLocalStorageState(
     "load-latest-eval",
     true,
+  )
+  const evalWebWorkerBlobUrl = props.evalWebWorkerBlobUrl ?? props.workerBlobUrl
+  const cacheApiBaseUrl = props.apiBaseUrl ?? API_BASE
+  const platformConfig = useMemo(
+    () => ({
+      ...props.platformConfig,
+      localCacheEngine:
+        props.platformConfig?.localCacheEngine ??
+        createCliLocalCacheEngine({ apiBaseUrl: cacheApiBaseUrl }),
+    }),
+    [cacheApiBaseUrl, props.platformConfig],
   )
   const [initialMainComponentPath] = useState<string | undefined>(() => {
     if (typeof window === "undefined") return undefined
@@ -26,9 +47,9 @@ export const RunFrameForCli = (props: {
     if (params.get("main_component") === mainComponentPath) return
     params.set("main_component", mainComponentPath)
     const newHash = params.toString()
-    const newUrl =
-      `${window.location.pathname}${window.location.search}` +
-      (newHash.length > 0 ? `#${newHash}` : "")
+    const newUrl = `${window.location.pathname}${window.location.search}${
+      newHash.length > 0 ? `#${newHash}` : ""
+    }`
     window.history.replaceState(null, "", newUrl)
   }, [])
 
@@ -39,10 +60,12 @@ export const RunFrameForCli = (props: {
       {LoginDialog}
       <RunFrameWithApi
         debug={props.debug}
-        forceLatestEvalVersion={!props.workerBlobUrl && shouldLoadLatestEval}
+        forceLatestEvalVersion={!evalWebWorkerBlobUrl && shouldLoadLatestEval}
         defaultToFullScreen={true}
         showToggleFullScreen={false}
-        workerBlobUrl={props.workerBlobUrl}
+        evalWebWorkerBlobUrl={evalWebWorkerBlobUrl}
+        apiBaseUrl={props.apiBaseUrl}
+        platformConfig={platformConfig}
         isCli={true}
         showFilesSwitch
         showFileMenu={false}
@@ -55,7 +78,7 @@ export const RunFrameForCli = (props: {
             <FileMenuLeftHeader
               isWebEmbedded={false}
               shouldLoadLatestEval={
-                !props.workerBlobUrl && shouldLoadLatestEval
+                !evalWebWorkerBlobUrl && shouldLoadLatestEval
               }
               onChangeShouldLoadLatestEval={(newShouldLoadLatestEval) => {
                 setLoadLatestEval(newShouldLoadLatestEval)

--- a/lib/components/RunFrameForCli/create-cli-local-cache-engine.ts
+++ b/lib/components/RunFrameForCli/create-cli-local-cache-engine.ts
@@ -1,0 +1,39 @@
+export interface CliLocalCacheEngine {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+}
+
+export const createCliLocalCacheEngine = ({
+  apiBaseUrl,
+  fetchImpl = globalThis.fetch.bind(globalThis),
+}: {
+  apiBaseUrl: string
+  fetchImpl?: typeof fetch
+}): CliLocalCacheEngine => {
+  const cacheApiUrl = `${apiBaseUrl.replace(/\/$/, "")}/cache`
+
+  return {
+    getItem: async (key) => {
+      try {
+        const response = await fetchImpl(
+          `${cacheApiUrl}?key=${encodeURIComponent(key)}`,
+        )
+        if (!response.ok) return null
+        return await response.text()
+      } catch {
+        return null
+      }
+    },
+    setItem: async (key, value) => {
+      try {
+        await fetchImpl(`${cacheApiUrl}?key=${encodeURIComponent(key)}`, {
+          method: "POST",
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+          body: value,
+        })
+      } catch {
+        // Cache failures should not prevent a circuit from rendering.
+      }
+    },
+  }
+}

--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -86,6 +86,7 @@ export interface RunFrameWithApiProps {
   evalWebWorkerBlobUrl?: string
   showFileMenu?: boolean
   schematicSvgOptions?: RunFrameProps["schematicSvgOptions"]
+  platformConfig?: RunFrameProps["platformConfig"]
   isCli?: boolean
 
   /**
@@ -303,6 +304,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
       evalVersion={props.evalVersion}
       forceLatestEvalVersion={props.forceLatestEvalVersion}
       evalWebWorkerBlobUrl={props.evalWebWorkerBlobUrl ?? props.workerBlobUrl}
+      platformConfig={props.platformConfig}
       enableFetchProxy={props.enableFetchProxy}
       leftHeaderContent={
         <div className="rf-flex rf-items-center rf-justify-between rf-w-full">

--- a/tests/create-cli-local-cache-engine.test.ts
+++ b/tests/create-cli-local-cache-engine.test.ts
@@ -1,0 +1,49 @@
+import { expect, mock, test } from "bun:test"
+import { createCliLocalCacheEngine } from "../lib/components/RunFrameForCli/create-cli-local-cache-engine"
+
+test("CLI cache engine reads entries through the file-server API", async () => {
+  const fetchImpl = mock(async () => new Response('{"traces":[]}'))
+  const cache = createCliLocalCacheEngine({
+    apiBaseUrl: "http://localhost:3020/api/",
+    fetchImpl: fetchImpl as typeof fetch,
+  })
+
+  expect(await cache.getItem("routes:core@1:srj:abc 123")).toBe('{"traces":[]}')
+  expect(fetchImpl).toHaveBeenCalledWith(
+    "http://localhost:3020/api/cache?key=routes%3Acore%401%3Asrj%3Aabc%20123",
+  )
+})
+
+test("CLI cache engine treats misses and request failures as cache misses", async () => {
+  const missingCache = createCliLocalCacheEngine({
+    apiBaseUrl: "/api",
+    fetchImpl: mock(
+      async () => new Response(null, { status: 404 }),
+    ) as typeof fetch,
+  })
+  const unavailableCache = createCliLocalCacheEngine({
+    apiBaseUrl: "/api",
+    fetchImpl: mock(async () => {
+      throw new Error("offline")
+    }) as typeof fetch,
+  })
+
+  expect(await missingCache.getItem("missing")).toBeNull()
+  expect(await unavailableCache.getItem("unavailable")).toBeNull()
+})
+
+test("CLI cache engine commits entries through the file-server API", async () => {
+  const fetchImpl = mock(async () => new Response(null, { status: 204 }))
+  const cache = createCliLocalCacheEngine({
+    apiBaseUrl: "/api",
+    fetchImpl: fetchImpl as typeof fetch,
+  })
+
+  await cache.setItem("routes:key", '{"traces":[]}')
+
+  expect(fetchImpl).toHaveBeenCalledWith("/api/cache?key=routes%3Akey", {
+    method: "POST",
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+    body: '{"traces":[]}',
+  })
+})


### PR DESCRIPTION
## What

- have `RunFrameForCli` create an HTTP-backed `localCacheEngine` using the file-server API
- pass that cache through `RunFrameWithApi` as ordinary platform configuration
- forward RunFrame's public `platformConfig` prop to the eval worker's actual `platform` option
- preserve explicit cache overrides and fail open when the cache API is unavailable
- forward the standalone bundle's injected eval-worker URL through the CLI wrapper

## Why

CLI-hosted RunFrame previously created its eval worker without a local cache engine, so browser autorouting neither read nor committed Core's persistent cache. RunFrame already has the correct Comlink path for proxying platform functions into the worker, but its `platformConfig` was being forwarded under a configuration key that `@tscircuit/eval` does not consume.

RunFrame is the right owner for the browser-side cache adapter. The CLI only needs to expose persistent storage through its file-server API; Core does not need a global worker bootstrap hook.

## Impact

When RunFrame is in CLI mode, Core receives a normal `platform.localCacheEngine`. Cache reads and writes are proxied back to RunFrame and persisted by the CLI at the project cache endpoint. Other RunFrame integrations remain unchanged, and callers can still supply an explicit cache engine.

Depends on the `/api/cache` storage endpoint in tscircuit/cli#3997.

## Checks

- `bun test` (37 passing)
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`

