### PR TITLE
Fix ErrorTabContent hook order

### DIFF
--- a/lib/components/ErrorTabContent/ErrorTabContent.tsx
+++ b/lib/components/ErrorTabContent/ErrorTabContent.tsx
@@ -123,6 +123,32 @@ export const ErrorTabContent = ({
     window.open(issueUrl, "_blank")
   }
 
+  // Store execution error globally so bug report dialog can access it
+  useEffect(() => {
+    if (errorMessage) {
+      let errorText = errorMessage
+      if (errorStack) {
+        errorText += `\n\n${errorStack}`
+      }
+      if (typeof window !== "undefined") {
+        window.__TSCIRCUIT_LAST_EXECUTION_ERROR = errorText
+      }
+    }
+  }, [errorMessage, errorStack])
+
+  const [expandedErrors, setExpandedErrors] = useState<Set<number>>(() => {
+    const allIndexes = new Set<number>()
+    unifiedErrors.forEach((_, i) => allIndexes.add(i))
+    return allIndexes
+  })
+  const [expandedWarnings, setExpandedWarnings] = useState<Set<number>>(() => {
+    const allIndexes = new Set<number>()
+    unifiedWarnings.forEach((_, i) => allIndexes.add(i))
+    return allIndexes
+  })
+  const [errorsCollapsed, setErrorsCollapsed] = useState(false)
+  const [warningsCollapsed, setWarningsCollapsed] = useState(false)
+
   if (unifiedErrors.length === 0 && unifiedWarnings.length === 0) {
     return (
       <div className="px-2">
@@ -156,32 +182,6 @@ export const ErrorTabContent = ({
       </div>
     )
   }
-
-  // Store execution error globally so bug report dialog can access it
-  useEffect(() => {
-    if (errorMessage) {
-      let errorText = errorMessage
-      if (errorStack) {
-        errorText += `\n\n${errorStack}`
-      }
-      if (typeof window !== "undefined") {
-        window.__TSCIRCUIT_LAST_EXECUTION_ERROR = errorText
-      }
-    }
-  }, [errorMessage, errorStack])
-
-  const [expandedErrors, setExpandedErrors] = useState<Set<number>>(() => {
-    const allIndexes = new Set<number>()
-    unifiedErrors.forEach((_, i) => allIndexes.add(i))
-    return allIndexes
-  })
-  const [expandedWarnings, setExpandedWarnings] = useState<Set<number>>(() => {
-    const allIndexes = new Set<number>()
-    unifiedWarnings.forEach((_, i) => allIndexes.add(i))
-    return allIndexes
-  })
-  const [errorsCollapsed, setErrorsCollapsed] = useState(false)
-  const [warningsCollapsed, setWarningsCollapsed] = useState(false)
 
   const toggleError = (index: number) => {
     setExpandedErrors((prev) => {


### PR DESCRIPTION
## Summary

- move the error telemetry effect and error/warning expansion state hooks above the empty-state return
- keep the existing error-tab behavior while ensuring every render executes hooks in the same order

## Root cause

`ErrorTabContent` returned early when no errors or warnings were present, but called one `useEffect` and four `useState` hooks after that return. During development, resolving an error changed the component from the full hook path to the early-return path, causing React to throw `Rendered fewer hooks than expected`. The inverse transition could throw `Rendered more hooks than during the previous render`.

## Impact

Error and warning state changes in `tsci dev` no longer crash the entire RunFrame error boundary. Refreshing the dev server is no longer required to recover from this hook-order failure.

## Validation

- reproduced and verified the error → clean → error component transition
- `bun test` (37 passed)
- `bun run build`
- `git diff --check`