### PR TITLE
Show React component stack in RunFrame errors

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -105,6 +105,7 @@ export const RunFrame = (props: RunFrameProps) => {
     error?: string
     stack?: string
   } | null>(null)
+  const [componentStack, setComponentStack] = useState<string | null>(null)
   const cancelExecutionRef = useRef<(() => void) | null>(null)
   const [autoroutingGraphics, setAutoroutingGraphics] = useState<any>(null)
   const [runCountTrigger, incRunCountTrigger] = useReducer(
@@ -624,7 +625,18 @@ export const RunFrame = (props: RunFrameProps) => {
   }
 
   return (
-    <ErrorBoundary FallbackComponent={RunFrameErrorFallback}>
+    <ErrorBoundary
+      onError={(_error, info) => {
+        setComponentStack(info.componentStack ?? null)
+      }}
+      onReset={() => setComponentStack(null)}
+      fallbackRender={(fallbackProps) => (
+        <RunFrameErrorFallback
+          {...fallbackProps}
+          componentStack={componentStack}
+        />
+      )}
+    >
       <CircuitJsonPreview
         code={fsMap.get(props.entrypoint ?? props.mainComponentPath)}
         fsMap={fsMap}

--- a/lib/components/RunFrame/RunFrameErrorFallback.tsx
+++ b/lib/components/RunFrame/RunFrameErrorFallback.tsx
@@ -2,10 +2,15 @@ import { AlertTriangle } from "lucide-react"
 import { Button } from "../ui/button"
 import type { FallbackProps } from "react-error-boundary"
 
+interface RunFrameErrorFallbackProps extends FallbackProps {
+  componentStack?: string | null
+}
+
 export const RunFrameErrorFallback = ({
   error,
   resetErrorBoundary,
-}: FallbackProps) => {
+  componentStack,
+}: RunFrameErrorFallbackProps) => {
   const resolvedError =
     error instanceof Error ? error : new Error(String(error))
 
@@ -33,6 +38,16 @@ export const RunFrameErrorFallback = ({
                 </summary>
                 <pre className="rf-text-xs rf-font-mono no-scrollbar rf-whitespace-pre-wrap rf-text-gray-500 rf-bg-gray-100 rf-p-3 rf-rounded-lg rf-mt-2 rf-overflow-auto rf-text-left rf-max-h-[150px]">
                   {resolvedError.stack}
+                </pre>
+              </details>
+            )}
+            {componentStack && (
+              <details className="rf-text-center rf-mb-6">
+                <summary className="rf-text-xs rf-text-gray-500 rf-cursor-pointer hover:rf-text-gray-700">
+                  View component stack
+                </summary>
+                <pre className="rf-text-xs rf-font-mono no-scrollbar rf-whitespace-pre-wrap rf-text-gray-500 rf-bg-gray-100 rf-p-3 rf-rounded-lg rf-mt-2 rf-overflow-auto rf-text-left rf-max-h-[150px]">
+                  {componentStack}
                 </pre>
               </details>
             )}

--- a/tests/runframe-error-fallback.test.tsx
+++ b/tests/runframe-error-fallback.test.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { RunFrameErrorFallback } from "../lib/components/RunFrame/RunFrameErrorFallback"
+
+test("RunFrameErrorFallback shows the React component stack", () => {
+  const html = renderToStaticMarkup(
+    <RunFrameErrorFallback
+      error={new Error("Rendered fewer hooks than expected")}
+      resetErrorBoundary={() => {}}
+      componentStack={
+        "\n    at CircuitJsonPreview (CircuitJsonPreview.tsx:42)\n    at RunFrame (RunFrame.tsx:99)"
+      }
+    />,
+  )
+
+  expect(html).toContain("View component stack")
+  expect(html).toContain("CircuitJsonPreview")
+  expect(html).toContain("RunFrame")
+})


### PR DESCRIPTION
## Summary

- capture React's `componentStack` when the RunFrame error boundary catches a render error
- show it in a separate collapsible diagnostic below the JavaScript stack trace
- clear the captured stack when the error boundary is reset
- add a focused fallback rendering test

This makes hook-order failures identify the component tree that was rendering, which should make the remaining development-only cases much easier to trace.

## Validation

- `bun test` (38 pass)
- `bun run build`
- `git diff --check`

No lint configuration or lint dependency changes are included.