### PR TITLE
Handle oversized autorouting bug reports with actionable RunFrame errors

### DIFF
--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -603,12 +603,22 @@ export const RunFrame = (props: RunFrameProps) => {
         const isUnauthorized =
           error instanceof HTTPError && error.response?.status === 401
 
+        const isPayloadTooLarge =
+          error instanceof HTTPError && error.response?.status === 413
+
         if (isUnauthorized) {
           if (props.onLoginRequired) {
             props.onLoginRequired()
           } else {
             alert("You must be logged in to report autorouting bugs")
           }
+          return
+        }
+
+        if (isPayloadTooLarge) {
+          alert(
+            "This autorouting log is too large to report online. Download the log and attach it to a GitHub issue.",
+          )
           return
         }
 


### PR DESCRIPTION
## Summary

Improve RunFrame feedback when autorouting bug reports fail because the payload exceeds the API size limit.

## Changes

- Detect `413 Content Too Large` responses from the autorouting bug-report endpoint.
- Show a clear alert explaining that the log is too large to submit online.
- Direct users to download the autorouting log and attach it to a GitHub issue.
- Preserve existing alert behavior for authentication and generic failures.

## Impact

Users now receive actionable guidance instead of an opaque HTTP error when reporting large autorouting logs.

## Validation

- `bun test tests/runframe-error-fallback.test.tsx`
- `bunx tsc --noEmit`
- `bunx biome check lib/components/RunFrame/RunFrame.tsx`