### PR TITLE
Update easyeda to 0.0.280

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "comlink": "^4.4.2",
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
-        "easyeda": "^0.0.279",
+        "easyeda": "^0.0.280",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -973,7 +973,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.279", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-Bdbb4yI/Y4z4dI5KvgTchtenhYxdqhdgA9FdPe9a0uUlwKWU/CO7ufJiTDQzXNgHWpEpFv2nOJefRd4ORMH8Xw=="],
+    "easyeda": ["easyeda@0.0.280", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-koIHZ6edDs7rL7qziEmvrQx/XoXdJzhUZEHuklZKEMxfbqB3kvvR5WrOU+hPkcYUaYuoGlSwFWMUat64w1bFeg=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "comlink": "^4.4.2",
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
-    "easyeda": "^0.0.279",
+    "easyeda": "^0.0.280",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary

- update `easyeda` from `^0.0.279` to `^0.0.280`
- refresh the Bun lockfile

## Why

easyeda 0.0.280 contains the symbol-generation fix from tscircuit/easyeda-converter#420, removing explicit `strokeWidth` properties from imported EasyEDA symbol elements.

## Impact

Runframe's JLCPCB import path resolves the latest released EasyEDA converter behavior.

## Validation

- `bun test`: 39 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run format:check`
