### PR TITLE
Declare Core as a direct dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@tscircuit/runframe",
       "dependencies": {
+        "@tscircuit/core": "^0.0.1633",
         "@tscircuit/eval": "^0.0.1162",
         "@tscircuit/solver-utils": "^0.0.7",
         "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "@tscircuit/core": "^0.0.1633",
     "@tscircuit/eval": "^0.0.1162",
     "@tscircuit/solver-utils": "^0.0.7",
     "debug": "^4.4.0"


### PR DESCRIPTION
### Motivation
- Ensure Runframe installs the Core version that exposes Matchpack in the solver registry.

### Before
- Runframe imported `@tscircuit/core` through a transitive dependency.

### After
- Runframe declares `@tscircuit/core` as a direct dependency.
