### PR TITLE
version update to Improve EasyEDA imports: passive primitives, parsing, symbols, aliases, and arc layers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "comlink": "^4.4.2",
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
-        "easyeda": "^0.0.294",
+        "easyeda": "^0.0.301",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -975,7 +975,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.294", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-+XoJlT3M9+kaVwP06e/pmpKQQXGC7z1xyUQq8i454sssHO/YKbtdDtfjGp5MAUUrhPaFfd4oG+ZXb8BqzCzzUA=="],
+    "easyeda": ["easyeda@0.0.301", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-O0dPOFJgmcYvYeBA6+6Fey9gaRe4VOVfeVh06F1whzCPQOZu+SQtEVW5X5QN014bL78b4VDtPyjXu6ldmfq6HA=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "comlink": "^4.4.2",
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
-    "easyeda": "^0.0.294",
+    "easyeda": "^0.0.301",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary

Update the EasyEDA converter dependency from `^0.0.294` to `^0.0.301`.

This brings the following import improvements into Runframe:

- Recognize capacitors as capacitor primitives when they have valid capacitance values, including normalization of `µF` to `uF`.
- Recognize standard SMD resistors as resistor primitives, including packages such as `R0402`, `R0603`, and `R0805`.
- Normalize resistor values such as `10kΩ`, `4R7`, `1M`, and `0Ω`.
- Preserve and generate EasyEDA schematic symbols for capacitor and resistor imports, including capacitor arrays.
- Normalize active-low pin aliases such as `#RESET` to safe `N_RESET` labels.
- Accept malformed or inconsistent EasyEDA payload variants, including numeric-string LCSC IDs, missing or empty `utime` values, and `P` text alignment.
- Preserve top/bottom layer information for arc geometry.

No Runframe application code changes were required; only the dependency declaration and lockfile were updated.

## Validation

- `bun test tests/direct-jlcpcb-lookup.test.ts tests/circuit-json-converters-dynamic-import.test.ts`
  - 6 tests passed.
- `bunx tsc --noEmit`
  - Passed.
- `git diff --check`
  - Passed.

## Files changed

- `package.json`
- `bun.lock`