### PR TITLE
show repeated solver instances in the solvers tab

### DIFF
--- a/examples/example58-autolayout-section.fixture.tsx
+++ b/examples/example58-autolayout-section.fixture.tsx
@@ -7,38 +7,47 @@ export default () => (
       "main.tsx": `
 circuit.add(
   <board width="20mm" height="10mm" routingDisabled>
-    <schematicsection name="power" displayName="Power" />
-    <schematicsection name="control" displayName="Control" />
+    <schematicsection name="decoupling" displayName="Decoupling" />
+    <schematicsection name="indicator" displayName="Status Indicator" />
 
-    <resistor
-      name="R1"
-      resistance="1k"
-      footprint="0402"
-      pcbX={-6}
-      schSectionName="power"
-    />
     <capacitor
       name="C1"
       capacitance="1uF"
       footprint="0402"
-      pcbX={-2}
-      schSectionName="power"
-    />
-
-    <resistor
-      name="R2"
-      resistance="10k"
-      footprint="0402"
-      pcbX={2}
-      schSectionName="control"
+      pcbX={-6}
+      schSectionName="decoupling"
     />
     <capacitor
       name="C2"
       capacitance="100nF"
       footprint="0402"
-      pcbX={6}
-      schSectionName="control"
+      pcbX={-2}
+      schSectionName="decoupling"
     />
+
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0402"
+      pcbX={2}
+      schSectionName="indicator"
+    />
+    <led
+      name="D1"
+      color="green"
+      footprint="0603"
+      pcbX={6}
+      schSectionName="indicator"
+    />
+
+    <trace from={"net.VCC"} to={".C1 > .pin1"} />
+    <trace from={".C1 > .pin2"} to={"net.GND"} />
+    <trace from={"net.VCC"} to={".C2 > .pin1"} />
+    <trace from={".C2 > .pin2"} to={"net.GND"} />
+
+    <trace from={"net.VCC"} to={".R1 > .pin1"} />
+    <trace from={".R1 > .pin2"} to={".D1 > .pin1"} />
+    <trace from={".D1 > .pin2"} to={"net.GND"} />
   </board>,
 )
 `,

--- a/examples/example58-autolayout-section.fixture.tsx
+++ b/examples/example58-autolayout-section.fixture.tsx
@@ -1,0 +1,50 @@
+import { RunFrame } from "lib/components/RunFrame/RunFrame"
+import React from "react"
+
+export default () => (
+  <RunFrame
+    fsMap={{
+      "main.tsx": `
+circuit.add(
+  <board width="20mm" height="10mm" routingDisabled>
+    <schematicsection name="power" displayName="Power" />
+    <schematicsection name="control" displayName="Control" />
+
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0402"
+      pcbX={-6}
+      schSectionName="power"
+    />
+    <capacitor
+      name="C1"
+      capacitance="1uF"
+      footprint="0402"
+      pcbX={-2}
+      schSectionName="power"
+    />
+
+    <resistor
+      name="R2"
+      resistance="10k"
+      footprint="0402"
+      pcbX={2}
+      schSectionName="control"
+    />
+    <capacitor
+      name="C2"
+      capacitance="100nF"
+      footprint="0402"
+      pcbX={6}
+      schSectionName="control"
+    />
+  </board>,
+)
+`,
+    }}
+    entrypoint="main.tsx"
+    defaultActiveTab="solvers"
+    showRunButton
+  />
+)

--- a/lib/components/RunFrame/RunFrame.tsx
+++ b/lib/components/RunFrame/RunFrame.tsx
@@ -386,15 +386,7 @@ export const RunFrame = (props: RunFrameProps) => {
       })
       worker.on("solver:started", (event: SolverStartedEvent) => {
         debug("solver:started", event)
-        setSolverEvents((prev) => {
-          // Deduplicate by componentName-solverName to avoid counting the same solver multiple times
-          const id = `${event.componentName}-${event.solverName}`
-          const exists = prev.some(
-            (e) => `${e.componentName}-${e.solverName}` === id,
-          )
-          if (exists) return prev
-          return [...prev, event]
-        })
+        setSolverEvents((prev) => [...prev, event])
       })
       worker.on("board:renderPhaseStarted", (event: any) => {
         renderLog.lastRenderEvent = event

--- a/lib/components/SolversTabContent/SolversTabContent.tsx
+++ b/lib/components/SolversTabContent/SolversTabContent.tsx
@@ -166,24 +166,21 @@ const SolverReportIconButton = ({
 export const SolversTabContent = ({
   solverEvents = [],
 }: SolversTabContentProps) => {
-  const [selectedSolverId, setSelectedSolverId] = useState<string | null>(null)
+  const [selectedSolverIndex, setSelectedSolverIndex] = useState<number | null>(
+    null,
+  )
 
   useInjectTailwind()
 
-  const solversById = useMemo(() => {
-    const map = new Map<string, SolverStartedEvent>()
-    for (const event of solverEvents) {
-      const id = `${event.componentName}-${event.solverName}`
-      map.set(id, event)
-    }
-    return map
-  }, [solverEvents])
+  let selectedSolverEvent: SolverStartedEvent | null = null
+  if (selectedSolverIndex !== null) {
+    selectedSolverEvent = solverEvents[selectedSolverIndex] ?? null
+  }
 
-  const solverIds = useMemo(() => Array.from(solversById.keys()), [solversById])
-
-  const selectedSolverEvent = selectedSolverId
-    ? solversById.get(selectedSolverId)
-    : null
+  let solverCountNoun = "Solvers"
+  if (solverEvents.length === 1) {
+    solverCountNoun = "Solver"
+  }
 
   // Reconstruct the solver instance from the event
   const solverResult = useMemo<SolverResult>(() => {
@@ -242,20 +239,19 @@ export const SolversTabContent = ({
       {/* Solver List Sidebar */}
       <div className="rf-w-64 rf-border-r rf-border-gray-200 rf-overflow-y-auto rf-flex-shrink-0">
         <div className="rf-text-xs rf-font-semibold rf-text-gray-500 rf-px-3 rf-py-2 rf-bg-gray-50 rf-border-b rf-border-gray-200">
-          {solverIds.length} {solverIds.length === 1 ? "Solver" : "Solvers"}
+          {solverEvents.length} {solverCountNoun}
         </div>
-        {solverIds.map((id) => {
-          const solver = solversById.get(id)!
-          const isSelected = selectedSolverId === id
+        {solverEvents.map((solver, solverIndex) => {
+          const isSelected = selectedSolverIndex === solverIndex
           return (
             <div
-              key={id}
+              key={solverIndex}
               className={`rf-px-3 rf-py-2 rf-cursor-pointer rf-border-b rf-border-gray-100 ${
                 isSelected
                   ? "rf-bg-blue-50 rf-border-l-2 rf-border-l-blue-500"
                   : "hover:rf-bg-gray-50"
               }`}
-              onClick={() => setSelectedSolverId(id)}
+              onClick={() => setSelectedSolverIndex(solverIndex)}
             >
               {(() => {
                 const SolverIcon = getSolverIcon(solver.solverName)

--- a/tests/solvers-tab-content.test.tsx
+++ b/tests/solvers-tab-content.test.tsx
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import type { SolverStartedEvent } from "../lib/components/CircuitJsonPreview/PreviewContentProps"
+import { SolversTabContent } from "../lib/components/SolversTabContent/SolversTabContent"
+
+test("shows separate solver instances with the same component and solver names", () => {
+  const solverEvent: SolverStartedEvent = {
+    type: "solver:started",
+    solverName: "LayoutPipelineSolver",
+    solverParams: {},
+    componentName: "<board#1 />",
+  }
+
+  const html = renderToStaticMarkup(
+    <SolversTabContent solverEvents={[solverEvent, solverEvent]} />,
+  )
+
+  expect(html).toContain("2 Solvers")
+  expect(html.match(/LayoutPipelineSolver/g)).toHaveLength(2)
+})


### PR DESCRIPTION
show every solver event in the solvers tab instead of collapsing matching instances, with an autolayout-section example for verification.