### PR TITLE
chore: update easyeda converter to 0.0.305

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "comlink": "^4.4.2",
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
-        "easyeda": "^0.0.301",
+        "easyeda": "^0.0.305",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -975,7 +975,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.301", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-O0dPOFJgmcYvYeBA6+6Fey9gaRe4VOVfeVh06F1whzCPQOZu+SQtEVW5X5QN014bL78b4VDtPyjXu6ldmfq6HA=="],
+    "easyeda": ["easyeda@0.0.305", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-ZwF3z+A2BkdZPKKznYasufwUeRFF3Tt6UP53LI9m4ER633XGBJyrbS220W3zSnOLjmqcpWCyNTlknU+5LY84Jw=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "comlink": "^4.4.2",
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
-    "easyeda": "^0.0.301",
+    "easyeda": "^0.0.305",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary

Update Runframe's `easyeda` dependency from `^0.0.301` to the latest published `^0.0.305`. This pulls in the converter improvements released in `0.0.302` through `0.0.305`.

## Included upstream changes

- `0.0.302`: adds regression coverage and a repro fixture for the oversized C8545 schematic symbol.
- `0.0.303`: supports additional EasyEDA payload variants, including numeric-string or blank LCSC/SZLCBSC prices, missing fill styles, and `AR`/`I` annotations that can be safely ignored instead of rejecting an otherwise usable payload.
- `0.0.304`: preserves standalone oval PCB holes when generating tscircuit footprint TSX.
- `0.0.305`: includes ports in imported passive symbols and aligns custom-symbol ports to drawing endpoints while preserving pin direction and stem length.

## Runframe changes

- Updated `package.json` to `easyeda@^0.0.305`.
- Refreshed `bun.lock` with the `0.0.305` package resolution and integrity hash.

## Impact

EasyEDA imports should handle more real-world payloads, retain oval-hole geometry, and produce more complete and correctly aligned passive-symbol schematics.

## Validation

- `bun run build:lib`
- `bun test tests/circuit-json-converters-dynamic-import.test.ts`
- Result: build passed and 2 tests passed.