### PR TITLE
Update EasyEDA converter to fix bottom-layer plated-hole previews

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "comlink": "^4.4.2",
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
-        "easyeda": "^0.0.307",
+        "easyeda": "^0.0.309",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -975,7 +975,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.307", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-4jmSN2hTghI1357Qq3EbTC7V/w4lx9S02kbfYb5ocLGbP67synkeT3rw7y/eFmp27FvuRtUMEh2uLEDgFKHtpw=="],
+    "easyeda": ["easyeda@0.0.309", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-FY8nGheXqUOS8XPbUaN1NXY8WNDpQj6SfE3BeMYFswO7xXZIb7qk47nhDInN3jaLoG5V+xvJROVtyrjXSIhmCw=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "comlink": "^4.4.2",
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
-    "easyeda": "^0.0.307",
+    "easyeda": "^0.0.309",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## What this fixes

Updates runframe to `easyeda@0.0.309`, which includes the merged EasyEDA converter fix for plated through-hole layer modeling.

The tscircuit.com Import Component preview could show a JLCPCB through-hole component incorrectly when the PCB viewer was switched to the bottom layer: the viewer changed layers correctly, but the imported plated holes were emitted with only `layers: ["top"]`. As a result, the bottom-layer preview did not render the plated holes as blue bottom copper.

The converter now emits `layers: ["top", "bottom"]` for through-hole plated pads. This PR makes runframe consume that released fix.

## User impact

This fixes the actual production behavior in the runframe-powered tscircuit.com import preview and keeps the preview consistent with the physical construction of plated through-holes.

## Screenshot

<img width="1177" height="592" alt="tscircuit.com bottom-layer plated-hole rendering bug" src="https://github.com/user-attachments/assets/891aefc0-7e9b-4e28-8b6d-c03aa86d0610" />

The screenshot shows the preview set to `layer: bottom` while the plated holes remain rendered as top-layer pads.

## Validation

- Focused JLCPCB import tests pass.
- runframe library build passes.
- Formatting and diff checks pass.
- The upstream converter regression test uses the reported `C75749` fixture.