### PR TITLE
Fix schematic viewer 2.0.81 compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@tscircuit/internal-dynamic-import": "^0.0.15",
         "@tscircuit/pcb-viewer": "1.11.390",
         "@tscircuit/props": "^0.0.612",
-        "@tscircuit/schematic-viewer": "^2.0.77",
+        "@tscircuit/schematic-viewer": "^2.0.81",
         "@types/bun": "latest",
         "@types/debug": "^4.1.12",
         "@types/react": "^19.1.10",
@@ -605,7 +605,7 @@
 
     "@tscircuit/schematic-trace-solver": ["@tscircuit/schematic-trace-solver@0.0.134", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-lfnY6zZnAtQonvclGed0TIb8U7MYSKBzNEjLaTg44AnXO/22huds8JSfUjhEF0qHPEhk0KxtH9tCLBQlNJk8IQ=="],
 
-    "@tscircuit/schematic-viewer": ["@tscircuit/schematic-viewer@2.0.77", "", { "dependencies": { "@radix-ui/react-dropdown-menu": "^2.1.16", "circuit-json": "^0.0.465", "circuit-to-svg": "^0.0.393", "debug": "^4.4.0", "performance-now": "^2.1.0", "use-mouse-matrix-transform": "^1.2.2" }, "peerDependencies": { "tscircuit": "*", "typescript": "^5.0.0" } }, "sha512-gp4+QcTwmvY8qRYnyNT+sIFEqm+rf5kI4KrAZwYcZagkBs2/2xAm+HMetdf3va0aWWn49uil7LqHxj+Tq2Vnjg=="],
+    "@tscircuit/schematic-viewer": ["@tscircuit/schematic-viewer@2.0.81", "", { "dependencies": { "@radix-ui/react-dropdown-menu": "^2.1.16", "@tscircuit/circuit-json-util": "^0.0.108", "circuit-json": "^0.0.465", "circuit-to-svg": "^0.0.393", "debug": "^4.4.0", "fflate": "^0.8.3", "performance-now": "^2.1.0", "use-mouse-matrix-transform": "^1.2.2" }, "peerDependencies": { "tscircuit": "*", "typescript": "^5.0.0" } }, "sha512-BBK3JfS/sUSX2Y1XzLIcsMFFhAyzbIgTzP1zRAdQn237yo1OC+cJOxi4zQxJylTLWNG1xHf+Fltnw2kxiicb6Q=="],
 
     "@tscircuit/simple-3d-svg": ["@tscircuit/simple-3d-svg@0.0.41", "", { "dependencies": { "fast-xml-parser": "^5.2.5", "fflate": "^0.8.2" } }, "sha512-2iwhHhMLElq5t0fcC0Gr7cCpZhEOAKh+6NN0NIJ9YWUCcsB7UN8uYko7jqNTxDlYOe6E0ZYaDZWsQ3amOZ3dlw=="],
 
@@ -1988,6 +1988,8 @@
     "@tscircuit/pcb-viewer/circuit-to-canvas": ["circuit-to-canvas@0.0.124", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-B9vQQizVZnV+fE0sSd479UVck6BRjSH44OMb1/53v3HVr8zP76KgysxOn5lQBDmo6lqlGERkhFICvE03sFklvQ=="],
 
     "@tscircuit/runframe/@tscircuit/eval": ["@tscircuit/eval@0.0.1222", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-ydzOlUCTXkLW965UappmGw8d8uaMArIiXtLCvxvHu9tQA9jpEurCmqP6I/9Utyq4rkDmN1/28ncdLAas3/ZRew=="],
+
+    "@tscircuit/schematic-viewer/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.108", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-6faP8DiOk+ShNUVBuVeThXYTTLTEMc3z+DJAxGTLnPl0ybwV9MKYSL6xwsRlVImZEEl+FMRN164e6sm11EXxMA=="],
 
     "@types/http-proxy/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -692,10 +692,6 @@ export const CircuitJsonPreview = ({
                       containerStyle={{
                         height: "100%",
                       }}
-                      editingEnabled
-                      onEditEvent={(ee) => {
-                        onEditEvent?.(ee)
-                      }}
                       debugGrid={showSchematicDebugGrid}
                       showSchematicPorts={showSchematicPorts}
                       css={schematicSvgOptions?.css}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/internal-dynamic-import": "^0.0.15",
     "@tscircuit/pcb-viewer": "1.11.390",
     "@tscircuit/props": "^0.0.612",
-    "@tscircuit/schematic-viewer": "^2.0.77",
+    "@tscircuit/schematic-viewer": "^2.0.81",
     "@types/bun": "latest",
     "@types/debug": "^4.1.12",
     "@types/react": "^19.1.10",


### PR DESCRIPTION
## Summary

- update `@tscircuit/schematic-viewer` from `2.0.77` to `2.0.81`
- remove the obsolete schematic `editingEnabled` and `onEditEvent` props
- keep runframe's edit-event API intact for PCB editing

## Root cause

`@tscircuit/schematic-viewer` removed its schematic component movement API in tscircuit/schematic-viewer#252. The automated dependency update in #4607 therefore failed type-checking because `CircuitJsonPreview` still passed the removed props, which prevented the viewer update from propagating through runframe to the CLI.

## Impact

Runframe can build against schematic-viewer 2.0.81. Schematic component dragging remains removed as intended upstream; PCB edit events continue to work.

## Validation

- `bunx tsc --noEmit`
- `bun run format:check`
- `bun test` (46 passed)
- `bun run build`
