### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -6,6 +6,11 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPOS: "cli,tscircuit.com" # for example: "eval"
   PACKAGE_NAMES: "@tscircuit/runframe" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/props"
@@ -22,16 +27,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release --no-push-main
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
       - name: Get package version

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "main": "dist/preview.js",
   "type": "module",
   "version": "0.0.2501",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/runframe"
+  },
   "exports": {
     ".": "./dist/preview.js",
     "./preview": "./dist/preview.js",


### PR DESCRIPTION
## Summary
- use npm trusted publishing with GitHub Actions OIDC instead of a long-lived NPM_TOKEN
- grant id-token: write and run Node 24 with npm 11+ support
- declare an explicit GitHub repository URL in package metadata where needed

## Required npm configuration
Before merge, the npm package must trust:
- GitHub repository: tscircuit/runframe
- Workflow: bun-pver-release.yml
- Allowed action: npm publish

## Validation
- package.json parsed successfully
- release workflow parsed successfully
- git diff --check