### PR TITLE
Handle wrapped solver constructor args from Core

### DIFF
--- a/lib/components/SolversTabContent/get-solver-constructor-args.ts
+++ b/lib/components/SolversTabContent/get-solver-constructor-args.ts
@@ -1,18 +1,4 @@
-import type { SOLVERS } from "@tscircuit/core"
 import type { SolverStartedEvent } from "../CircuitJsonPreview/PreviewContentProps"
-
-type AutoroutingPipeline7ConstructorArgs = ConstructorParameters<
-  (typeof SOLVERS)["AutoroutingPipelineSolver7_MultiGraph"]
->
-
-type CoreAutoroutingPipeline7Params = {
-  input: AutoroutingPipeline7ConstructorArgs[0]
-  options: AutoroutingPipeline7ConstructorArgs[1]
-}
-
-const unwrapCoreAutoroutingPipeline7Params = (
-  params: CoreAutoroutingPipeline7Params,
-): AutoroutingPipeline7ConstructorArgs => [params.input, params.options]
 
 export const getSolverConstructorArgs = (
   solverEvent: Pick<
@@ -20,24 +6,19 @@ export const getSolverConstructorArgs = (
     "solverName" | "solverParams" | "solverConstructorArgs"
   >,
 ): readonly unknown[] => {
+  const constructorArgs = solverEvent.solverConstructorArgs ?? [
+    solverEvent.solverParams,
+  ]
+
   if (
-    solverEvent.solverName === "AutoroutingPipelineSolver7_MultiGraph" &&
-    solverEvent.solverConstructorArgs?.length === 1
+    solverEvent.solverName !== "AutoroutingPipelineSolver7_MultiGraph" ||
+    constructorArgs.length !== 1
   ) {
-    return unwrapCoreAutoroutingPipeline7Params(
-      solverEvent.solverConstructorArgs[0] as CoreAutoroutingPipeline7Params,
-    )
+    return constructorArgs
   }
 
-  if (solverEvent.solverConstructorArgs) {
-    return solverEvent.solverConstructorArgs
-  }
-
-  if (solverEvent.solverName === "AutoroutingPipelineSolver7_MultiGraph") {
-    return unwrapCoreAutoroutingPipeline7Params(
-      solverEvent.solverParams as CoreAutoroutingPipeline7Params,
-    )
-  }
-
-  return [solverEvent.solverParams]
+  const [{ input, options }] = constructorArgs as readonly [
+    { input: unknown; options: unknown },
+  ]
+  return [input, options]
 }

--- a/lib/components/SolversTabContent/get-solver-constructor-args.ts
+++ b/lib/components/SolversTabContent/get-solver-constructor-args.ts
@@ -7,6 +7,17 @@ export const getSolverConstructorArgs = (
   >,
 ): readonly unknown[] => {
   if (Array.isArray(solverEvent.solverConstructorArgs)) {
+    const [onlyConstructorArg] = solverEvent.solverConstructorArgs
+    if (
+      solverEvent.solverConstructorArgs.length === 1 &&
+      onlyConstructorArg !== null &&
+      typeof onlyConstructorArg === "object" &&
+      "input" in onlyConstructorArg &&
+      "options" in onlyConstructorArg
+    ) {
+      return [onlyConstructorArg.input, onlyConstructorArg.options]
+    }
+
     return solverEvent.solverConstructorArgs
   }
 

--- a/lib/components/SolversTabContent/get-solver-constructor-args.ts
+++ b/lib/components/SolversTabContent/get-solver-constructor-args.ts
@@ -1,34 +1,43 @@
+import type { SOLVERS } from "@tscircuit/core"
 import type { SolverStartedEvent } from "../CircuitJsonPreview/PreviewContentProps"
+
+type AutoroutingPipeline7ConstructorArgs = ConstructorParameters<
+  (typeof SOLVERS)["AutoroutingPipelineSolver7_MultiGraph"]
+>
+
+type CoreAutoroutingPipeline7Params = {
+  input: AutoroutingPipeline7ConstructorArgs[0]
+  options: AutoroutingPipeline7ConstructorArgs[1]
+}
+
+const unwrapCoreAutoroutingPipeline7Params = (
+  params: CoreAutoroutingPipeline7Params,
+): AutoroutingPipeline7ConstructorArgs => [params.input, params.options]
 
 export const getSolverConstructorArgs = (
   solverEvent: Pick<
     SolverStartedEvent,
-    "solverParams" | "solverConstructorArgs"
+    "solverName" | "solverParams" | "solverConstructorArgs"
   >,
 ): readonly unknown[] => {
-  if (Array.isArray(solverEvent.solverConstructorArgs)) {
-    const [onlyConstructorArg] = solverEvent.solverConstructorArgs
-    if (
-      solverEvent.solverConstructorArgs.length === 1 &&
-      onlyConstructorArg !== null &&
-      typeof onlyConstructorArg === "object" &&
-      "input" in onlyConstructorArg &&
-      "options" in onlyConstructorArg
-    ) {
-      return [onlyConstructorArg.input, onlyConstructorArg.options]
-    }
+  if (
+    solverEvent.solverName === "AutoroutingPipelineSolver7_MultiGraph" &&
+    solverEvent.solverConstructorArgs?.length === 1
+  ) {
+    return unwrapCoreAutoroutingPipeline7Params(
+      solverEvent.solverConstructorArgs[0] as CoreAutoroutingPipeline7Params,
+    )
+  }
 
+  if (solverEvent.solverConstructorArgs) {
     return solverEvent.solverConstructorArgs
   }
 
-  const solverParams = solverEvent.solverParams
-  if (
-    solverParams !== null &&
-    typeof solverParams === "object" &&
-    "input" in solverParams
-  ) {
-    return [(solverParams as { input: unknown }).input]
+  if (solverEvent.solverName === "AutoroutingPipelineSolver7_MultiGraph") {
+    return unwrapCoreAutoroutingPipeline7Params(
+      solverEvent.solverParams as CoreAutoroutingPipeline7Params,
+    )
   }
 
-  return [solverParams]
+  return [solverEvent.solverParams]
 }

--- a/tests/autorouter-solver-constructor-replay.test.ts
+++ b/tests/autorouter-solver-constructor-replay.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { SOLVERS, type SimpleRouteJson } from "@tscircuit/core"
+import { getSolverConstructorArgs } from "lib/components/SolversTabContent/get-solver-constructor-args"
+
+test("reconstructs an autorouter from Core's wrapped constructor args", () => {
+  const input: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+  }
+  const solverParams = { input, options: { effort: 1 } }
+  const constructorArgs = getSolverConstructorArgs({
+    solverParams,
+    solverConstructorArgs: [solverParams],
+  })
+  const SolverClass = SOLVERS.AutoroutingPipelineSolver7_MultiGraph as new (
+    ...args: any[]
+  ) => unknown
+
+  expect(() => new SolverClass(...constructorArgs)).not.toThrow()
+})

--- a/tests/autorouter-solver-constructor-replay.test.ts
+++ b/tests/autorouter-solver-constructor-replay.test.ts
@@ -12,6 +12,7 @@ test("reconstructs an autorouter from Core's wrapped constructor args", () => {
   }
   const solverParams = { input, options: { effort: 1 } }
   const constructorArgs = getSolverConstructorArgs({
+    solverName: "AutoroutingPipelineSolver7_MultiGraph",
     solverParams,
     solverConstructorArgs: [solverParams],
   })

--- a/tests/get-solver-constructor-args.test.ts
+++ b/tests/get-solver-constructor-args.test.ts
@@ -11,6 +11,18 @@ test("uses exact solver constructor args with legacy fallbacks", () => {
   ).toBe(exactConstructorArgs)
 
   const legacyInput = { connections: [] }
+  const wrappedOptions = { effort: 1 }
+  const wrappedSolverParams = {
+    input: legacyInput,
+    options: wrappedOptions,
+  }
+  expect(
+    getSolverConstructorArgs({
+      solverParams: wrappedSolverParams,
+      solverConstructorArgs: [wrappedSolverParams],
+    }),
+  ).toEqual([legacyInput, wrappedOptions])
+
   expect(
     getSolverConstructorArgs({
       solverParams: { input: legacyInput, options: { effort: 1 } },

--- a/tests/get-solver-constructor-args.test.ts
+++ b/tests/get-solver-constructor-args.test.ts
@@ -5,6 +5,7 @@ test("uses exact solver constructor args with legacy fallbacks", () => {
   const exactConstructorArgs = [{ connections: [] }, { buses: [] }] as const
   expect(
     getSolverConstructorArgs({
+      solverName: "FanoutSolver",
       solverParams: exactConstructorArgs[0],
       solverConstructorArgs: exactConstructorArgs,
     }),
@@ -18,6 +19,7 @@ test("uses exact solver constructor args with legacy fallbacks", () => {
   }
   expect(
     getSolverConstructorArgs({
+      solverName: "AutoroutingPipelineSolver7_MultiGraph",
       solverParams: wrappedSolverParams,
       solverConstructorArgs: [wrappedSolverParams],
     }),
@@ -25,12 +27,16 @@ test("uses exact solver constructor args with legacy fallbacks", () => {
 
   expect(
     getSolverConstructorArgs({
+      solverName: "AutoroutingPipelineSolver7_MultiGraph",
       solverParams: { input: legacyInput, options: { effort: 1 } },
     }),
-  ).toEqual([legacyInput])
+  ).toEqual([legacyInput, { effort: 1 }])
 
   const legacyParams = { chips: [] }
-  expect(getSolverConstructorArgs({ solverParams: legacyParams })).toEqual([
-    legacyParams,
-  ])
+  expect(
+    getSolverConstructorArgs({
+      solverName: "LayoutPipelineSolver",
+      solverParams: legacyParams,
+    }),
+  ).toEqual([legacyParams])
 })


### PR DESCRIPTION
## Summary

- replay Core's wrapped Pipeline 7 parameters as `(input, options)`
- leave every other solver's constructor arguments unchanged
- cover the fix with unit and real-solver reconstruction tests

## Why

Core's default autorouter event currently has this shape:

```ts
{
  solverName: "AutoroutingPipelineSolver7_MultiGraph",
  solverParams: { input, options },
  solverConstructorArgs: [{ input, options }],
}
```

The registered `AutoroutingPipelineSolver7_MultiGraph` constructor takes two arguments:

```ts
new AutoroutingPipelineSolver7_MultiGraph(input, options)
```

RunFrame previously spread the one wrapped argument directly into the constructor, so the solver received the wrapper as its `SimpleRouteJson` and failed while reading `srj.obstacles.map(...)`.

RunFrame is the compatibility boundary for this event. It now handles the one known Pipeline 7 wrapper with a short solver-name check and does not probe arbitrary object shapes.

The event shape was introduced in https://github.com/tscircuit/core/pull/3277. Exact constructor-argument replay support was added in https://github.com/tscircuit/runframe/pull/4617.

## User impact

After a successful online autoroute, opening **RunFrame → Solvers** and selecting `AutoroutingPipelineSolver7_MultiGraph` no longer fails with:

```text
Failed to instantiate solver: Cannot read properties of undefined (reading 'map')
```

## Validation

- `bun test` — 47 passed, 0 failed
- `bunx tsc --noEmit`
- `bunx biome check lib/components/SolversTabContent/get-solver-constructor-args.ts tests/get-solver-constructor-args.test.ts tests/autorouter-solver-constructor-replay.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run build:lib`
- `git diff --check`
