### PR TITLE
Connect schematic components to focused PCB view

### DIFF
--- a/examples/example58-go-to-pcb-component.fixture.tsx
+++ b/examples/example58-go-to-pcb-component.fixture.tsx
@@ -1,0 +1,29 @@
+import { CircuitJsonPreview } from "lib/components/CircuitJsonPreview/CircuitJsonPreview"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+export default () => (
+  <CircuitJsonPreview
+    defaultActiveTab="schematic"
+    availableTabs={["schematic", "pcb"]}
+    circuitJson={renderToCircuitJson(
+      <board width="50mm" height="20mm">
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0603"
+          schX={-3}
+          pcbX={-18}
+        />
+        <capacitor
+          name="C1"
+          capacitance="1uF"
+          footprint="0805"
+          schX={3}
+          pcbX={18}
+          layer="bottom"
+        />
+        <trace from=".R1 .pin2" to=".C1 .pin1" />
+      </board>,
+    )}
+  />
+)

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -7,14 +7,7 @@ import {
 import { cn } from "lib/utils"
 import { hasSimulationAnalysisResult } from "lib/utils/has-simulation-analysis-result"
 import { CadViewer } from "@tscircuit/3d-viewer"
-import {
-  useCallback,
-  useEffect,
-  useState,
-  useMemo,
-  type ComponentProps,
-  type ComponentType,
-} from "react"
+import { useCallback, useEffect, useState, useMemo } from "react"
 import { ErrorFallback } from "../ErrorFallback"
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary"
 import { ErrorTabContent } from "../ErrorTabContent/ErrorTabContent"
@@ -70,7 +63,10 @@ import {
   shouldShowCrispFeedbackButton,
 } from "./CrispFeedbackButton"
 import type { PcbComponentFocusRequest } from "@tscircuit/pcb-viewer"
-import { navigateToPcbComponent } from "./pcb-component-navigation"
+import {
+  isPcbNavigationAvailable,
+  navigateToPcbComponent,
+} from "./pcb-component-navigation"
 
 declare global {
   interface Window {
@@ -88,15 +84,6 @@ const dropdownMenuItems = [
   "render_log",
   "solvers",
 ]
-
-// Keep forwarding the legacy editing props while runframe can still be used
-// with schematic-viewer versions that support schematic movement.
-const RunframeSchematicViewer = SchematicViewer as ComponentType<
-  ComponentProps<typeof SchematicViewer> & {
-    editingEnabled?: boolean
-    onEditEvent?: PreviewContentProps["onEditEvent"]
-  }
->
 
 export type { PreviewContentProps, TabId, SolverStartedEvent }
 
@@ -260,6 +247,12 @@ export const CircuitJsonPreview = ({
     },
     [setActiveTab],
   )
+  let schematicPcbNavigationHandler:
+    | typeof handleNavigateToPcbComponent
+    | undefined
+  if (isPcbNavigationAvailable(availableTabs)) {
+    schematicPcbNavigationHandler = handleNavigateToPcbComponent
+  }
 
   const toggleFullScreen = () => {
     setIsFullScreen(!isFullScreen)
@@ -713,24 +706,16 @@ export const CircuitJsonPreview = ({
                   )}
                 >
                   {circuitJson ? (
-                    <RunframeSchematicViewer
+                    <SchematicViewer
                       circuitJson={circuitJson}
                       containerStyle={{
                         height: "100%",
-                      }}
-                      editingEnabled
-                      onEditEvent={(editEvent) => {
-                        onEditEvent?.(editEvent)
                       }}
                       debugGrid={showSchematicDebugGrid}
                       showSchematicPorts={showSchematicPorts}
                       css={schematicSvgOptions?.css}
                       className={schematicSvgOptions?.className}
-                      onNavigateToPcbComponent={
-                        !availableTabs || availableTabs.includes("pcb")
-                          ? handleNavigateToPcbComponent
-                          : undefined
-                      }
+                      onNavigateToPcbComponent={schematicPcbNavigationHandler}
                     />
                   ) : (
                     <PreviewEmptyState onRunClicked={onRunClicked} />

--- a/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview/CircuitJsonPreview.tsx
@@ -13,6 +13,7 @@ import {
   useState,
   useMemo,
   type ComponentProps,
+  type ComponentType,
 } from "react"
 import { ErrorFallback } from "../ErrorFallback"
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary"
@@ -68,6 +69,8 @@ import {
   CrispFeedbackButton,
   shouldShowCrispFeedbackButton,
 } from "./CrispFeedbackButton"
+import type { PcbComponentFocusRequest } from "@tscircuit/pcb-viewer"
+import { navigateToPcbComponent } from "./pcb-component-navigation"
 
 declare global {
   interface Window {
@@ -85,6 +88,15 @@ const dropdownMenuItems = [
   "render_log",
   "solvers",
 ]
+
+// Keep forwarding the legacy editing props while runframe can still be used
+// with schematic-viewer versions that support schematic movement.
+const RunframeSchematicViewer = SchematicViewer as ComponentType<
+  ComponentProps<typeof SchematicViewer> & {
+    editingEnabled?: boolean
+    onEditEvent?: PreviewContentProps["onEditEvent"]
+  }
+>
 
 export type { PreviewContentProps, TabId, SolverStartedEvent }
 
@@ -207,6 +219,9 @@ export const CircuitJsonPreview = ({
     activeTab,
   })
   const [lastActiveTab, setLastActiveTab] = useState<TabId | null>(null)
+  const [pcbComponentFocusRequest, setPcbComponentFocusRequest] = useState<
+    PcbComponentFocusRequest | undefined
+  >()
   const [isFullScreen, setIsFullScreen] = useState(defaultToFullScreen)
 
   // Internal state for when CircuitJsonPreview is used standalone (without external state management)
@@ -234,6 +249,16 @@ export const CircuitJsonPreview = ({
       onActiveTabChange?.(tab)
     },
     [onActiveTabChange, setActiveTabState],
+  )
+  const handleNavigateToPcbComponent = useCallback(
+    (options: Parameters<typeof navigateToPcbComponent>[0]["options"]) => {
+      navigateToPcbComponent({
+        options,
+        setPcbComponentFocusRequest,
+        setActiveTab,
+      })
+    },
+    [setActiveTab],
   )
 
   const toggleFullScreen = () => {
@@ -571,6 +596,7 @@ export const CircuitJsonPreview = ({
                     <PcbViewerWithContainerHeight
                       focusOnHover={false}
                       circuitJson={circuitJson}
+                      pcbComponentFocusRequest={pcbComponentFocusRequest}
                       debugGraphics={autoroutingGraphics}
                       onBoundsSelected={onPcbBoundsSelected}
                       containerClassName={cn(
@@ -687,19 +713,24 @@ export const CircuitJsonPreview = ({
                   )}
                 >
                   {circuitJson ? (
-                    <SchematicViewer
+                    <RunframeSchematicViewer
                       circuitJson={circuitJson}
                       containerStyle={{
                         height: "100%",
                       }}
                       editingEnabled
-                      onEditEvent={(ee) => {
-                        onEditEvent?.(ee)
+                      onEditEvent={(editEvent) => {
+                        onEditEvent?.(editEvent)
                       }}
                       debugGrid={showSchematicDebugGrid}
                       showSchematicPorts={showSchematicPorts}
                       css={schematicSvgOptions?.css}
                       className={schematicSvgOptions?.className}
+                      onNavigateToPcbComponent={
+                        !availableTabs || availableTabs.includes("pcb")
+                          ? handleNavigateToPcbComponent
+                          : undefined
+                      }
                     />
                   ) : (
                     <PreviewEmptyState onRunClicked={onRunClicked} />

--- a/lib/components/CircuitJsonPreview/pcb-component-navigation.ts
+++ b/lib/components/CircuitJsonPreview/pcb-component-navigation.ts
@@ -1,6 +1,12 @@
 import type { PcbComponentFocusRequest } from "@tscircuit/pcb-viewer"
 import type { NavigateToPcbComponentOptions } from "@tscircuit/schematic-viewer"
 import type { Dispatch, SetStateAction } from "react"
+import type { TabId } from "./PreviewContentProps"
+
+export const isPcbNavigationAvailable = (availableTabs?: TabId[]) => {
+  if (!availableTabs) return true
+  return availableTabs.includes("pcb")
+}
 
 export const createNextPcbComponentFocusRequest = (
   previousRequest: PcbComponentFocusRequest | undefined,

--- a/lib/components/CircuitJsonPreview/pcb-component-navigation.ts
+++ b/lib/components/CircuitJsonPreview/pcb-component-navigation.ts
@@ -1,0 +1,28 @@
+import type { PcbComponentFocusRequest } from "@tscircuit/pcb-viewer"
+import type { NavigateToPcbComponentOptions } from "@tscircuit/schematic-viewer"
+import type { Dispatch, SetStateAction } from "react"
+
+export const createNextPcbComponentFocusRequest = (
+  previousRequest: PcbComponentFocusRequest | undefined,
+  pcbComponentId: string,
+): PcbComponentFocusRequest => ({
+  pcbComponentId,
+  requestId: (previousRequest?.requestId ?? 0) + 1,
+})
+
+export const navigateToPcbComponent = ({
+  options,
+  setPcbComponentFocusRequest,
+  setActiveTab,
+}: {
+  options: NavigateToPcbComponentOptions
+  setPcbComponentFocusRequest: Dispatch<
+    SetStateAction<PcbComponentFocusRequest | undefined>
+  >
+  setActiveTab: (tab: "pcb") => void
+}) => {
+  setPcbComponentFocusRequest((previousRequest) =>
+    createNextPcbComponentFocusRequest(previousRequest, options.pcbComponentId),
+  )
+  setActiveTab("pcb")
+}

--- a/tests/pcb-component-navigation.test.ts
+++ b/tests/pcb-component-navigation.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import type { PcbComponentFocusRequest } from "@tscircuit/pcb-viewer"
+import {
+  createNextPcbComponentFocusRequest,
+  navigateToPcbComponent,
+} from "../lib/components/CircuitJsonPreview/pcb-component-navigation"
+
+test("schematic navigation switches to PCB and forwards a repeatable focus request", () => {
+  let focusRequest: PcbComponentFocusRequest | undefined
+  const activeTabs: string[] = []
+  const setPcbComponentFocusRequest = (
+    update:
+      | PcbComponentFocusRequest
+      | undefined
+      | ((
+          previous: PcbComponentFocusRequest | undefined,
+        ) => PcbComponentFocusRequest | undefined),
+  ) => {
+    focusRequest = typeof update === "function" ? update(focusRequest) : update
+  }
+  const options = {
+    schematicComponentId: "schematic_component_1",
+    sourceComponentId: "source_component_1",
+    pcbComponentId: "pcb_component_1",
+  }
+
+  navigateToPcbComponent({
+    options,
+    setPcbComponentFocusRequest,
+    setActiveTab: (tab) => {
+      activeTabs.push(tab)
+    },
+  })
+
+  expect(activeTabs).toEqual(["pcb"])
+  expect(focusRequest).toEqual({
+    pcbComponentId: "pcb_component_1",
+    requestId: 1,
+  })
+
+  navigateToPcbComponent({
+    options,
+    setPcbComponentFocusRequest,
+    setActiveTab: (tab) => {
+      activeTabs.push(tab)
+    },
+  })
+  expect(activeTabs).toEqual(["pcb", "pcb"])
+  expect(focusRequest).toEqual({
+    pcbComponentId: "pcb_component_1",
+    requestId: 2,
+  })
+  expect(
+    createNextPcbComponentFocusRequest(focusRequest, "pcb_component_2"),
+  ).toEqual({ pcbComponentId: "pcb_component_2", requestId: 3 })
+})

--- a/tests/pcb-component-navigation.test.ts
+++ b/tests/pcb-component-navigation.test.ts
@@ -2,8 +2,15 @@ import { expect, test } from "bun:test"
 import type { PcbComponentFocusRequest } from "@tscircuit/pcb-viewer"
 import {
   createNextPcbComponentFocusRequest,
+  isPcbNavigationAvailable,
   navigateToPcbComponent,
 } from "../lib/components/CircuitJsonPreview/pcb-component-navigation"
+
+test("PCB navigation follows the available tabs", () => {
+  expect(isPcbNavigationAvailable()).toBe(true)
+  expect(isPcbNavigationAvailable(["schematic", "pcb"])).toBe(true)
+  expect(isPcbNavigationAvailable(["schematic"])).toBe(false)
+})
 
 test("schematic navigation switches to PCB and forwards a repeatable focus request", () => {
   let focusRequest: PcbComponentFocusRequest | undefined
@@ -16,7 +23,11 @@ test("schematic navigation switches to PCB and forwards a repeatable focus reque
           previous: PcbComponentFocusRequest | undefined,
         ) => PcbComponentFocusRequest | undefined),
   ) => {
-    focusRequest = typeof update === "function" ? update(focusRequest) : update
+    if (typeof update === "function") {
+      focusRequest = update(focusRequest)
+    } else {
+      focusRequest = update
+    }
   }
   const options = {
     schematicComponentId: "schematic_component_1",


### PR DESCRIPTION
## Summary

Completes schematic-to-PCB component navigation in `CircuitJsonPreview`.

- handles schematic navigation callbacks at the tab-owning host boundary
- stores a monotonically increasing PCB focus request so repeated navigation retriggers focus
- switches through the existing active-tab setter, preserving `onActiveTabChange`
- forwards controlled focus requests to `PCBViewer`
- exposes navigation only when the PCB tab is available
- adds a fixture with widely separated top- and bottom-layer components
- covers tab switching and repeat-request behavior

## PR chain

**Part 3 of 3 — integration PR.**

1. [tscircuit/schematic-viewer#262](https://github.com/tscircuit/schematic-viewer/pull/262) — navigation callback
2. [tscircuit/pcb-viewer#963](https://github.com/tscircuit/pcb-viewer/pull/963) — controlled component focus
3. **This PR:** runframe tab and focus integration

## Dependency order

This draft depends on parts 1 and 2 being merged and released. After those releases, update runframe's `@tscircuit/schematic-viewer` and `@tscircuit/pcb-viewer` versions before marking this ready for review.

## Validation

Validated with the two upstream worktrees linked locally:

- `bun test` — 47 passed
- formatting check
- TypeScript check
- package and standalone builds
- live fixture verified for top- and bottom-layer focus with zero browser console errors
