### PR TITLE
Use shared Gerber file generation for fabrication exports

### DIFF
--- a/lib/optional-features/exporting/formats/export-fabrication-files.ts
+++ b/lib/optional-features/exporting/formats/export-fabrication-files.ts
@@ -1,9 +1,10 @@
 import importer from "@tscircuit/internal-dynamic-import"
 import type { AnyCircuitElement } from "circuit-json"
-import type * as CircuitJsonToGerber from "circuit-json-to-gerber"
 import JSZip from "jszip"
 import { toast } from "lib/utils/toast"
 import { openForDownload } from "../open-for-download"
+
+type CircuitJsonToGerber = typeof import("circuit-json-to-gerber")
 
 type PnpCsvConverter = (
   circuitJson: AnyCircuitElement[],
@@ -29,9 +30,7 @@ export const exportFabricationFiles = async ({
         { convertCircuitJsonToBomRows, convertBomRowsToCsv },
         { convertCircuitJsonToPickAndPlaceCsv },
       ] = await Promise.all([
-        importer("circuit-json-to-gerber") as Promise<
-          typeof CircuitJsonToGerber
-        >,
+        importer("circuit-json-to-gerber") as Promise<CircuitJsonToGerber>,
         importer("circuit-json-to-bom-csv"),
         importer("circuit-json-to-pnp-csv"),
       ])

--- a/lib/optional-features/exporting/formats/export-fabrication-files.ts
+++ b/lib/optional-features/exporting/formats/export-fabrication-files.ts
@@ -1,5 +1,6 @@
 import importer from "@tscircuit/internal-dynamic-import"
 import type { AnyCircuitElement } from "circuit-json"
+import type * as CircuitJsonToGerber from "circuit-json-to-gerber"
 import JSZip from "jszip"
 import { toast } from "lib/utils/toast"
 import { openForDownload } from "../open-for-download"
@@ -24,16 +25,13 @@ export const exportFabricationFiles = async ({
       const zip = new JSZip()
 
       const [
-        {
-          stringifyGerberCommandLayers,
-          convertSoupToGerberCommands,
-          convertSoupToExcellonDrillCommands,
-          stringifyExcellonDrill,
-        },
+        gerberConverter,
         { convertCircuitJsonToBomRows, convertBomRowsToCsv },
         { convertCircuitJsonToPickAndPlaceCsv },
       ] = await Promise.all([
-        importer("circuit-json-to-gerber"),
+        importer("circuit-json-to-gerber") as Promise<
+          typeof CircuitJsonToGerber
+        >,
         importer("circuit-json-to-bom-csv"),
         importer("circuit-json-to-pnp-csv"),
       ])
@@ -43,26 +41,15 @@ export const exportFabricationFiles = async ({
         (element) => !("error_type" in element) && !("warning_type" in element),
       ) as any
 
-      // Generate Gerber files
-      const gerberLayerCmds = convertSoupToGerberCommands(filteredCircuitJson, {
-        flip_y_axis: false,
-      })
-      const gerberFileContents = stringifyGerberCommandLayers(gerberLayerCmds)
-
-      for (const [fileName, fileContents] of Object.entries(
-        gerberFileContents,
-      )) {
-        zip.file(`gerber/${fileName}.gbr`, fileContents)
+      const gerberFiles = gerberConverter.convertCircuitJsonToGerberFiles(
+        filteredCircuitJson,
+        {
+          flip_y_axis: false,
+        },
+      )
+      for (const [fileName, fileContents] of Object.entries(gerberFiles)) {
+        zip.file(`gerber/${fileName}`, fileContents)
       }
-
-      // Generate Drill files
-      const drillCmds = convertSoupToExcellonDrillCommands({
-        circuitJson: filteredCircuitJson,
-        is_plated: true,
-        flip_y_axis: false,
-      })
-      const drillFileContents = stringifyExcellonDrill(drillCmds)
-      zip.file("gerber/drill.drl", drillFileContents)
 
       // Generate BOM CSV
       const bomRows = await convertCircuitJsonToBomRows({ circuitJson })


### PR DESCRIPTION
## Summary
- consume convertCircuitJsonToGerberFiles from circuit-json-to-gerber@0.0.97
- keep dynamic runtime loading while using the published package for authoritative types
- package the returned Gerber/Excellon file map alongside BOM and JLCPCB PnP outputs
- remove duplicated conversion flags, stringification, and drill selection

## Impact
RunFrame fabrication downloads now include through-hole, blind/buried, and NPTH drill files using the same implementation as the converter CLI.

## Validation
- bunx tsc --noEmit
- bun run build:lib
- Biome formatting
- git diff --check