### PR TITLE
chore: update easyeda to 0.0.342

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
         "comlink": "^4.4.2",
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
-        "easyeda": "^0.0.316",
+        "easyeda": "^0.0.342",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -977,7 +977,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.316", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-iRdJHZnYBAhE93IVYAsSGzVNLqJyIA1OHIG6cUL1Vf/ClRNLssN1NfrPBUPcFKsZ54PwAwVEkZe5VMJKLthN8A=="],
+    "easyeda": ["easyeda@0.0.342", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-g9uMcU+u9N/F/vCRpCHLWc16Qq5bh4x0IEvV9ah2kjblWTlFZ4oYtrYpaZDUzxkH6b8c2EnhM97y/OdNliS6wQ=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "comlink": "^4.4.2",
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
-    "easyeda": "^0.0.316",
+    "easyeda": "^0.0.342",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary

- update easyeda from 0.0.316 to 0.0.342
- refresh the Bun lockfile entry

## Testing

- bun install --frozen-lockfile
- bun test
- bunx tsc --noEmit
- bun run format:check