### PR TITLE
chore: update easyeda to 0.0.350

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
         "comlink": "^4.4.2",
         "concurrently": "^9.1.2",
         "cssnano": "^7.0.6",
-        "easyeda": "^0.0.342",
+        "easyeda": "^0.0.350",
         "fflate": "^0.8.2",
         "fuse.js": "^7.1.0",
         "jose": "^6.1.0",
@@ -977,7 +977,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.342", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-g9uMcU+u9N/F/vCRpCHLWc16Qq5bh4x0IEvV9ah2kjblWTlFZ4oYtrYpaZDUzxkH6b8c2EnhM97y/OdNliS6wQ=="],
+    "easyeda": ["easyeda@0.0.350", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-CpTBmNoVGzSzZH4IY00sTv2AqeRRzB4kUU3360xWSOrWBCB8VJF774a/oCQcrGgj2nw0kEhrfoCKtIsyWAGtpg=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "comlink": "^4.4.2",
     "concurrently": "^9.1.2",
     "cssnano": "^7.0.6",
-    "easyeda": "^0.0.342",
+    "easyeda": "^0.0.350",
     "fflate": "^0.8.2",
     "fuse.js": "^7.1.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
RunFrame still declares and locks EasyEDA 0.0.342. This updates the dependency to `^0.0.350` and regenerates `bun.lock` so installs resolve the current release.

The intervening releases fix conversion issues relevant to imported JLCPCB/EasyEDA components:
- Preserve rectangular through-hole pads and their dimensions/rotation ([#524](https://github.com/tscircuit/easyeda-converter/pull/524)).
- Derive CAD component sizes from model bounds ([#540](https://github.com/tscircuit/easyeda-converter/pull/540)).
- Preserve the C7519 schematic body fill and visible diodes ([#543](https://github.com/tscircuit/easyeda-converter/pull/543)).

The browser importer already loads `easyeda@latest` from jsDelivr. This PR brings the declared dependency and reproducible install in line with the current release; it does not change that browser loading behavior. Only `package.json` and `bun.lock` change.

Validation: `bun test` (47 passed), `bunx tsc --noEmit`, and `git diff --check` all passed.
