### PR TITLE
Fix npm release failure from circuit-json override

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -25,3 +25,11 @@ jobs:
 
       - name: Run tests
         run: bun test
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Validate npm package
+        run: npm pack --dry-run --ignore-scripts

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
   },
   "overrides": {
-    "circuit-json": "0.0.484",
+    "circuit-json": "^0.0.484",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/package.json
+++ b/package.json
@@ -126,6 +126,6 @@
     "format-si-unit": "^0.0.12"
   },
   "overrides": {
-    "circuit-json": "0.0.484"
+    "circuit-json": "$circuit-json"
   }
 }


### PR DESCRIPTION
Publishing runframe fails with `EOVERRIDE` because its direct `circuit-json` dependency uses `^0.0.484` while the override uses `0.0.484`. Reference the direct dependency with `$circuit-json` so npm accepts the override and automated dependency updates keep it in sync. Regenerate the Bun lockfile without changing resolved package versions.

Add `npm pack --dry-run --ignore-scripts` to the required test job using Node 24, matching the release workflow. This catches npm manifest validation failures before merge without publishing a package.

Validation: reproduced `EOVERRIDE` using the original manifest; the same npm pack dry run passes with the fix. Bun 1.4.2 regenerated the lockfile with only the override range changed.

Fixes the [failed release](https://github.com/tscircuit/runframe/actions/runs/34002053857/job/101402553013).
