### PR TITLE
Add Altium project export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "autoprefixer": "^10.4.20",
         "chokidar-cli": "^3.0.0",
         "circuit-json": "^0.0.484",
-        "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#72d97e867283de953bc9a0235f8c7f6a92fc008d",
+        "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#5bdb7d235ef896ddf9ac5c4f315c4d0ce07fdfb5",
         "circuit-json-to-bom-csv": "^0.0.15",
         "circuit-json-to-gerber": "^0.0.105",
         "circuit-json-to-kicad": "^0.0.206",
@@ -815,7 +815,7 @@
 
     "circuit-json": ["circuit-json@0.0.484", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-m89c37vr7NebvYtIjyaMxMAQoj3PRp30LILnX86JsWZQ2OWlsb70/abllW60x4/MSSHpgbjMaokVH/Jzt7n1ig=="],
 
-    "circuit-json-to-altium": ["circuit-json-to-altium@github:tscircuit/circuit-json-to-altium#72d97e8", { "dependencies": { "altiumts": "github:tscircuit/altiumts#6c8af3de0e50c7d918f7f2bf43cca5af604cf9cc", "cfb": "^1.2.2", "circuit-json": "^0.0.480", "color-string": "2.1.4", "jszip": "^3.10.1", "schematic-symbols": "^0.0.239", "transformation-matrix": "^3.1.0" } }, "tscircuit-circuit-json-to-altium-72d97e8", "sha512-/kfmWx6tf1Fzkc1OGURWb9OOAp/Yax+ojCl4bP0uMzaUQWYIJeNvMYXAwTn20bFRUoilaQE2tSGfjxStB5IdfQ=="],
+    "circuit-json-to-altium": ["circuit-json-to-altium@github:tscircuit/circuit-json-to-altium#5bdb7d2", { "dependencies": { "altiumts": "github:tscircuit/altiumts#6c8af3de0e50c7d918f7f2bf43cca5af604cf9cc", "cfb": "^1.2.2", "circuit-json": "^0.0.480", "color-string": "2.1.4", "jszip": "^3.10.1", "schematic-symbols": "^0.0.239", "transformation-matrix": "^3.1.0" } }, "tscircuit-circuit-json-to-altium-5bdb7d2", "sha512-4FBJFzmPMacUp/PC4DFNKGM03CcBFpO1C3a4ClWosKgbbByYxFMHrd8SlrenGbcx40Sc0EHAQmwr68LrB63E1A=="],
 
     "circuit-json-to-bom-csv": ["circuit-json-to-bom-csv@0.0.15", "", { "dependencies": { "format-si-prefix": "^0.3.2", "lucide-react": "^1.23.0", "papaparse": "^5.4.1", "react": "^19.2.7", "react-dom": "^19.2.7" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-FkX9QlU4H2oLUqeI5ohLQJiTJcMvSHHCcmawtuuI+TRyh5gDd2nd6PiAB8mkTjrKEQ93bDkGzn9z74VyPWdB7g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "autoprefixer": "^10.4.20",
         "chokidar-cli": "^3.0.0",
         "circuit-json": "^0.0.484",
+        "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#72d97e867283de953bc9a0235f8c7f6a92fc008d",
         "circuit-json-to-bom-csv": "^0.0.15",
         "circuit-json-to-gerber": "^0.0.105",
         "circuit-json-to-kicad": "^0.0.206",
@@ -98,6 +99,7 @@
     },
   },
   "overrides": {
+    "altiumts": "0.0.59",
     "circuit-json": "^0.0.484",
   },
   "packages": {
@@ -679,7 +681,11 @@
 
     "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
+    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "altiumts": ["altiumts@0.0.59", "", { "dependencies": { "cfb": "^1.2.2", "fflate": "^0.8.3" }, "peerDependencies": { "typescript": "^5" }, "bin": { "altiumts": "dist/cli.js" } }, "sha512-EunWtSs0FXEnxN9G10PvZyplDwcaE8/ioML3nnzqlAlGeKcnkKGHLpKBL0aUjg0i4yCovzn6ZihroBFhsi/6XA=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
@@ -793,6 +799,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001806", "", {}, "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="],
 
+    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "chalk-template": ["chalk-template@0.4.0", "", { "dependencies": { "chalk": "^4.1.2" } }, "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg=="],
@@ -806,6 +814,8 @@
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "circuit-json": ["circuit-json@0.0.484", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-m89c37vr7NebvYtIjyaMxMAQoj3PRp30LILnX86JsWZQ2OWlsb70/abllW60x4/MSSHpgbjMaokVH/Jzt7n1ig=="],
+
+    "circuit-json-to-altium": ["circuit-json-to-altium@github:tscircuit/circuit-json-to-altium#72d97e8", { "dependencies": { "altiumts": "github:tscircuit/altiumts#6c8af3de0e50c7d918f7f2bf43cca5af604cf9cc", "cfb": "^1.2.2", "circuit-json": "^0.0.480", "color-string": "2.1.4", "jszip": "^3.10.1", "schematic-symbols": "^0.0.239", "transformation-matrix": "^3.1.0" } }, "tscircuit-circuit-json-to-altium-72d97e8", "sha512-/kfmWx6tf1Fzkc1OGURWb9OOAp/Yax+ojCl4bP0uMzaUQWYIJeNvMYXAwTn20bFRUoilaQE2tSGfjxStB5IdfQ=="],
 
     "circuit-json-to-bom-csv": ["circuit-json-to-bom-csv@0.0.15", "", { "dependencies": { "format-si-prefix": "^0.3.2", "lucide-react": "^1.23.0", "papaparse": "^5.4.1", "react": "^19.2.7", "react-dom": "^19.2.7" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-FkX9QlU4H2oLUqeI5ohLQJiTJcMvSHHCcmawtuuI+TRyh5gDd2nd6PiAB8mkTjrKEQ93bDkGzn9z74VyPWdB7g=="],
 
@@ -859,9 +869,9 @@
 
     "color-diff": ["color-diff@1.4.0", "", {}, "sha512-4oDB/o78lNdppbaqrg0HjOp7pHmUc+dfCxWKWFnQg6AB/1dkjtBDop3RZht5386cq9xBUDRvDvSCA7WUlM9Jqw=="],
 
-    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+    "color-name": ["color-name@2.1.1", "", {}, "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg=="],
 
-    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
 
     "comlink": ["comlink@4.4.2", "", {}, "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="],
 
@@ -900,6 +910,8 @@
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
+
+    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -2037,6 +2049,10 @@
 
     "chokidar-cli/yargs": ["yargs@13.3.2", "", { "dependencies": { "cliui": "^5.0.0", "find-up": "^3.0.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^3.0.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^13.1.2" } }, "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw=="],
 
+    "circuit-json-to-altium/schematic-symbols": ["schematic-symbols@0.0.239", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-H+bx5oF+jj10jT42zz6SnGxzDxsHW1MrGz/15d4eDFT78lFnoK9zZ7DQBSLCSL60lqhc+LY+j7ttsokf84OLaA=="],
+
+    "circuit-json-to-altium/transformation-matrix": ["transformation-matrix@3.1.0", "", {}, "sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA=="],
+
     "circuit-json-to-bom-csv/lucide-react": ["lucide-react@1.27.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw=="],
 
     "circuit-json-to-bom-csv/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
@@ -2056,6 +2072,10 @@
     "clipboardy/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "color/color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -2298,6 +2318,8 @@
     "chokidar-cli/yargs/yargs-parser": ["yargs-parser@13.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg=="],
 
     "circuit-json-to-bom-csv/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "color/color-string/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/lib/optional-features/exporting/export-and-download.ts
+++ b/lib/optional-features/exporting/export-and-download.ts
@@ -1,5 +1,6 @@
 import type { CircuitJson } from "circuit-json"
 import { sanitizeFileName } from "lib/utils/sanitizeFileName"
+import { exportAltiumProject } from "./formats/export-altium-project"
 import { exportFabricationFiles } from "./formats/export-fabrication-files"
 import { exportFdmComponentBox } from "./formats/export-fdm-component-box"
 import { exportGlb } from "./formats/export-glb"
@@ -15,6 +16,7 @@ export const availableExports = [
   { extension: "json", name: "Simple Route JSON" },
   { extension: "zip", name: "Fabrication Files" },
   { extension: "zip", name: "KiCad Project" },
+  { extension: "zip", name: "Altium Project" },
   { extension: "zip", name: "KiCad Library" },
   { extension: "glb", name: "GLB (Binary GLTF)" },
   { extension: "svg", name: "Pinout SVG" },
@@ -53,6 +55,10 @@ export const exportAndDownload = async ({
   }
   if (exportName === "KiCad Project") {
     await exportKicadProject({ circuitJson, projectName })
+    return
+  }
+  if (exportName === "Altium Project") {
+    await exportAltiumProject({ circuitJson, projectName })
     return
   }
   if (exportName === "KiCad Library") {

--- a/lib/optional-features/exporting/formats/export-altium-project.ts
+++ b/lib/optional-features/exporting/formats/export-altium-project.ts
@@ -1,0 +1,43 @@
+import type { CircuitJson } from "circuit-json"
+import { toast } from "lib/utils/toast"
+import { openForDownload } from "../open-for-download"
+
+export const createAltiumProjectZip = async ({
+  circuitJson,
+  projectName,
+}: {
+  circuitJson: CircuitJson
+  projectName: string
+}) => {
+  // Bundle the pinned Git dependency lazily; it is not yet on the importer CDN.
+  const { convertCircuitJsonToAltiumZip } = await import(
+    "circuit-json-to-altium"
+  )
+  const bytes = await convertCircuitJsonToAltiumZip(circuitJson, projectName)
+  return new Blob([new Uint8Array(bytes)], { type: "application/zip" })
+}
+
+export const exportAltiumProject = async ({
+  circuitJson,
+  projectName,
+}: {
+  circuitJson: CircuitJson
+  projectName: string
+}) => {
+  await toast.promise(
+    (async () => {
+      const zipBlob = await createAltiumProjectZip({ circuitJson, projectName })
+      openForDownload(zipBlob, {
+        fileName: `${projectName}_altium_project.zip`,
+      })
+    })(),
+    {
+      loading: "Generating Altium project...",
+      success: "Altium project ZIP ready",
+      error: (error) =>
+        `Failed to generate Altium project: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    },
+  )
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "autoprefixer": "^10.4.20",
     "chokidar-cli": "^3.0.0",
     "circuit-json": "^0.0.484",
-    "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#72d97e867283de953bc9a0235f8c7f6a92fc008d",
+    "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#5bdb7d235ef896ddf9ac5c4f315c4d0ce07fdfb5",
     "circuit-json-to-bom-csv": "^0.0.15",
     "circuit-json-to-gerber": "^0.0.105",
     "circuit-json-to-kicad": "^0.0.206",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "autoprefixer": "^10.4.20",
     "chokidar-cli": "^3.0.0",
     "circuit-json": "^0.0.484",
+    "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#72d97e867283de953bc9a0235f8c7f6a92fc008d",
     "circuit-json-to-bom-csv": "^0.0.15",
     "circuit-json-to-gerber": "^0.0.105",
     "circuit-json-to-kicad": "^0.0.206",
@@ -126,6 +127,7 @@
     "format-si-unit": "^0.0.12"
   },
   "overrides": {
-    "circuit-json": "$circuit-json"
+    "circuit-json": "$circuit-json",
+    "altiumts": "0.0.59"
   }
 }

--- a/tests/export-altium-project.test.ts
+++ b/tests/export-altium-project.test.ts
@@ -1,0 +1,75 @@
+import { expect, mock, test } from "bun:test"
+import JSZip from "jszip"
+import {
+  availableExports,
+  exportAndDownload,
+} from "../lib/optional-features/exporting/export-and-download"
+
+test("Altium menu export downloads native documents with a sanitized project name", async () => {
+  expect(availableExports).toContainEqual({
+    extension: "zip",
+    name: "Altium Project",
+  })
+  const originalDocument = globalThis.document
+  const originalCreateObjectURL = URL.createObjectURL
+  let downloadedBlob: Blob | undefined
+  const anchor = {
+    download: "",
+    href: "",
+    style: { display: "" },
+    click: mock(() => {}),
+  } as unknown as HTMLAnchorElement
+
+  try {
+    globalThis.document = {
+      body: { appendChild: () => anchor, removeChild: () => anchor },
+      createElement: () => anchor,
+    } as unknown as Document
+    URL.createObjectURL = (blob) => {
+      downloadedBlob = blob as Blob
+      return "blob:altium-test"
+    }
+
+    await exportAndDownload({
+      exportName: "Altium Project",
+      projectName: "example/board",
+      circuitJson: [
+        {
+          type: "pcb_board",
+          pcb_board_id: "pcb_board_1",
+          center: { x: 0, y: 0 },
+          width: 10,
+          height: 10,
+          num_layers: 2,
+          material: "fr4",
+          thickness: 1.4,
+        },
+      ],
+    })
+
+    expect(anchor.download).toBe("example_board_altium_project.zip")
+    expect(anchor.click).toHaveBeenCalledTimes(1)
+    expect(downloadedBlob?.type).toBe("application/zip")
+    const zip = await JSZip.loadAsync(await downloadedBlob!.arrayBuffer())
+    expect(Object.keys(zip.files).sort()).toEqual([
+      "README.txt",
+      "example_board.PcbDoc",
+      "example_board.PrjPcb",
+      "example_board.SchDoc",
+    ])
+    for (const extension of ["PcbDoc", "SchDoc"]) {
+      const bytes = await zip
+        .file(`example_board.${extension}`)!
+        .async("uint8array")
+      expect(Array.from(bytes.slice(0, 8))).toEqual([
+        0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1,
+      ])
+    }
+    const project = await zip.file("example_board.PrjPcb")!.async("string")
+    expect(project).toContain("example_board.PcbDoc")
+    expect(project).toContain("example_board.SchDoc")
+  } finally {
+    globalThis.document = originalDocument
+    URL.createObjectURL = originalCreateObjectURL
+  }
+})


### PR DESCRIPTION
Adds **Altium Project** to runframe's export menu. The shared export dispatcher passes the current Circuit JSON and sanitized project name to `circuit-json-to-altium`, then downloads `<project>_altium_project.zip` containing native `.PcbDoc`, `.SchDoc`, and `.PrjPcb` documents. It uses the existing download helper and loading/success/error toasts.

The converter is loaded lazily from a pinned Git dependency (`5bdb7d235ef896ddf9ac5c4f315c4d0ce07fdfb5`) because it is not yet published on npm. Its transitive serializer is overridden to the published `altiumts@0.0.59` distribution, avoiding Git prepare-script failures on clean installs. This matches the integration in https://github.com/tscircuit/cli/pull/4657 and https://github.com/tscircuit/tscircuit.com/pull/4842.

Validation:
- Full Bun suite: 67 tests pass.
- New integration test covers menu registration, export dispatch, sanitized filename, ZIP MIME type, native PCB/schematic signatures, and project references.
- Type checking and formatting checks pass.
- `bun run build` passes, including standalone, standalone-preview, and library/declaration builds.
- Production export-module bundle tested in headless Chrome, including the actual ZIP download.

