### PR TITLE
fix: load the corrected GLB exporter for browser downloads

### DIFF
--- a/lib/optional-features/exporting/formats/export-glb.ts
+++ b/lib/optional-features/exporting/formats/export-glb.ts
@@ -11,7 +11,9 @@ export const exportGlb = async ({
 }) => {
   let blob: Blob
   try {
-    const { convertCircuitJsonToGltf } = await importer("circuit-json-to-gltf")
+    const { convertCircuitJsonToGltf } = await importer(
+      "circuit-json-to-gltf@0.0.124",
+    )
 
     console.log("convertCircuitJsonToGltf", convertCircuitJsonToGltf)
 


### PR DESCRIPTION
Load the versioned `circuit-json-to-gltf@0.0.124` module for GLB downloads. A versioned CDN request selects the release containing the corrected silkscreen font instead of relying on an unversioned cache.

The lowercase `v` in `74LVC1G08GW v1.0` appeared raised in 3D snapshots because the exporter embedded a stale font. The root fix is merged in https://github.com/tscircuit/circuit-json-to-gltf/pull/196 and published as `circuit-json-to-gltf@0.0.124`; it includes a pixel regression and reviewed snapshots.

Validation: Bundled the modified export function with `@tscircuit/internal-dynamic-import@0.0.15` and exercised it in headless Chrome using real CDN imports. Exported the `74LVC1G08GW v1.0` label circuit and verified GLB magic, a 16,992-byte output, and `model/gltf-binary` MIME type. Formatting and `git diff --check` passed. The full runframe suite was not run.